### PR TITLE
Fix recovery mode, add after and before sync in webhook workflows and filter out inactive object

### DIFF
--- a/app/controllers/maestrano/auth/saml_controller.rb
+++ b/app/controllers/maestrano/auth/saml_controller.rb
@@ -25,7 +25,7 @@ class Maestrano::Auth::SamlController < Maestrano::Rails::SamlBaseController
     end
 
     if session[:settings]
-      session.delete(:setting)
+      session.delete(:settings)
       redirect_to main_app.root_path
     else
       if current_organization && current_organization.oauth_uid && current_organization.sync_enabled

--- a/app/controllers/maestrano/connec_controller.rb
+++ b/app/controllers/maestrano/connec_controller.rb
@@ -5,31 +5,33 @@ class Maestrano::ConnecController < Maestrano::Rails::WebHookController
 
     begin
       params.except(:tenant, :controller, :action).each do |entity_name, entities|
-        if entity_instance_hash = find_entity_instance(entity_name)
-          entity_instance = entity_instance_hash[:instance]
 
-          entities.each do |entity|
-            if (organization = Maestrano::Connector::Rails::Organization.find_by(uid: entity[:group_id], tenant: params[:tenant])) && organization.oauth_uid
-              Maestrano::Connector::Rails::ConnectorLogger.log('info', organization, "Received entity from Connec! webhook: Entity=#{entity_name}, Data=#{entity}")
-              if organization.sync_enabled && organization.synchronized_entities[entity_instance_hash[:name].to_sym]
-                external_client = Maestrano::Connector::Rails::External.get_client(organization)
+        entity_instance_hash = find_entity_instance(entity_name)
+        next Rails.logger.info "Received notification from Connec! for unknow entity: #{entity_name}" unless entity_instance_hash
 
-                # Build expected input for consolidate_and_map_data
-                if entity_instance_hash[:is_complex]
-                  mapped_entity = entity_instance.consolidate_and_map_data(Hash[ *entity_instance.class.connec_entities_names.collect{|name| name.parameterize('_').pluralize == entity_name ? [name, [entity]] : [ name, []]}.flatten(1) ], Hash[ *entity_instance.class.external_entities_names.collect{|name| [ name, []]}.flatten(1) ], organization, {})
-                else
-                  mapped_entity = entity_instance.consolidate_and_map_data([entity], [], organization, {})
-                end
+        entity_instance = entity_instance_hash[:instance]
 
-                entity_instance.push_entities_to_external(external_client, mapped_entity[:connec_entities], organization)
-              end
+        entities.each do |entity|
+          organization = Maestrano::Connector::Rails::Organization.find_by_uid_and_tenant(entity[:group_id], params[:tenant])
+          next Rails.logger.warn "Received notification from Connec! for unknown group or group without oauth: #{entity['group_id']} (tenant: #{params[:tenant]})" unless organization && organization.oauth_uid
+          next unless organization.sync_enabled && organization.synchronized_entities[entity_instance_hash[:name].to_sym]
 
-            else
-              Rails.logger.warn "Received notification from Connec! for unknown group or group without oauth: #{entity['group_id']} (tenant: #{params[:tenant]})"
-            end
+
+          Maestrano::Connector::Rails::ConnectorLogger.log('info', organization, "Received entity from Connec! webhook: Entity=#{entity_name}, Data=#{entity}")
+          connec_client = Maestrano::Connec::Client[organization.tenant].new(organization.uid)
+          external_client = Maestrano::Connector::Rails::External.get_client(organization)
+          last_synchronization = organization.last_successful_synchronization
+
+          entity_instance.before_sync(connec_client, external_client, last_synchronization, organization, {})
+          # Build expected input for consolidate_and_map_data
+          if entity_instance_hash[:is_complex]
+            mapped_entity = entity_instance.consolidate_and_map_data(Hash[ *entity_instance.class.connec_entities_names.collect{|name| name.parameterize('_').pluralize == entity_name ? [name, [entity]] : [ name, []]}.flatten(1) ], Hash[ *entity_instance.class.external_entities_names.collect{|name| [ name, []]}.flatten(1) ], organization, {})
+          else
+            mapped_entity = entity_instance.consolidate_and_map_data([entity], [], organization, {})
           end
-        else
-          Rails.logger.info "Received notification from Connec! for unknow entity: #{entity_name}"
+          entity_instance.push_entities_to_external(external_client, mapped_entity[:connec_entities], organization)
+
+          entity_instance.after_sync(connec_client, external_client, last_synchronization, organization, {})
         end
       end
     rescue => e
@@ -38,7 +40,6 @@ class Maestrano::ConnecController < Maestrano::Rails::WebHookController
 
     head 200, content_type: "application/json"
   end
-
 
 
   private

--- a/app/jobs/maestrano/connector/rails/push_to_connec_job.rb
+++ b/app/jobs/maestrano/connector/rails/push_to_connec_job.rb
@@ -3,22 +3,29 @@ module Maestrano::Connector::Rails
     queue_as :default
 
     # expected hash: {"external_entity_name1" => [entity1, entity2], "external_entity_name2" => []}
-    def perform(organization, entities_hash)
+    def perform(organization, entities_hash, opts={})
       return unless organization.sync_enabled && organization.oauth_uid
 
       connec_client = Maestrano::Connec::Client[organization.tenant].new(organization.uid)
+      external_client = Maestrano::Connector::Rails::External.get_client(organization)
+      last_synchronization = organization.last_successful_synchronization
 
       entities_hash.each do |external_entity_name, entities|
         if entity_instance_hash = find_entity_instance(external_entity_name)
-          entity_instance = entity_instance_hash[:instance]
           next unless organization.synchronized_entities[entity_instance_hash[:name].to_sym]
+
+          entity_instance = entity_instance_hash[:instance]
+
+          entity_instance.before_sync(connec_client, external_client, last_synchronization, organization, opts)
+          # Build expected input for consolidate_and_map_data
           if entity_instance_hash[:is_complex]
             mapped_entities = entity_instance.consolidate_and_map_data(Hash[ *entity_instance.class.connec_entities_names.collect{|name| [ name, []]}.flatten(1) ], Hash[ *entity_instance.class.external_entities_names.collect{|name| name == external_entity_name ? [name, entities] : [ name, []]}.flatten(1) ], organization, {})
           else
             mapped_entities = entity_instance.consolidate_and_map_data([], entities, organization, {})
           end
-
           entity_instance.push_entities_to_connec(connec_client, mapped_entities[:external_entities], organization)
+
+          entity_instance.after_sync(connec_client, external_client, last_synchronization, organization, opts)
         else
           Rails.logger.warn "Called push to connec job with unknow entity: #{external_entity_name}"
         end

--- a/app/jobs/maestrano/connector/rails/synchronization_job.rb
+++ b/app/jobs/maestrano/connector/rails/synchronization_job.rb
@@ -3,7 +3,7 @@ module Maestrano::Connector::Rails
     queue_as :default
 
     # Supported options:
-    #  * :forced => true  synchronization has been triggered manually (for logging purposes only)
+    #  * :forced => true  synchronization has been triggered manually
     #  * :only_entities => [person, tasks_list]
     #  * :full_sync => true  synchronization is performed without date filtering
     #  * :connec_preemption => true|false : preemption is always|never given to connec in case of conflict (if not set, the most recently updated entity is kept)
@@ -17,8 +17,8 @@ module Maestrano::Connector::Rails
       end
 
       # Check if recovery mode: last 3 synchronizations have failed
-      if Synchronization.where(organization_id: organization.id, status: 'ERROR').order(created_at: :desc).limit(3).count == 3 \
-          && Synchronization.where(organization_id: organization.id).order(created_at: :desc).limit(1).first.updated_at > 1.day.ago
+      if !opts[:forced] && organization.last_three_synchronizations_failed? \
+          && organization.synchronizations.order(created_at: :desc).limit(1).first.updated_at > 1.day.ago
         ConnectorLogger.log('info', organization, "Synchronization skipped: Recovery mode (three previous synchronizations have failed)")
         return
       end

--- a/app/jobs/maestrano/connector/rails/synchronization_job.rb
+++ b/app/jobs/maestrano/connector/rails/synchronization_job.rb
@@ -28,7 +28,7 @@ module Maestrano::Connector::Rails
       current_synchronization = Synchronization.create_running(organization)
 
       begin
-        last_synchronization = Synchronization.where(organization_id: organization.id, status: 'SUCCESS', partial: false).order(updated_at: :desc).first
+        last_synchronization = organization.last_successful_synchronization
         connec_client = Maestrano::Connec::Client[organization.tenant].new(organization.uid)
         external_client = External.get_client(organization)
 

--- a/app/models/maestrano/connector/rails/concerns/entity.rb
+++ b/app/models/maestrano/connector/rails/concerns/entity.rb
@@ -171,7 +171,6 @@ module Maestrano::Connector::Rails::Concerns::Entity
   # * full_sync
   # * $filter (see Connec! documentation)
   # * $orderby (see Connec! documentation)
-  # * include_inactive - boolean - does not filter out inative object
   def get_connec_entities(client, last_synchronization, organization, opts={})
     return [] unless self.class.can_read_connec?
 
@@ -180,19 +179,17 @@ module Maestrano::Connector::Rails::Concerns::Entity
     entities = []
     query_params = {}
     query_params[:$orderby] = opts[:$orderby] if opts[:$orderby]
-    filter = []
-    filter << "status ne 'INACTIVE'" unless opts[:include_inactive]
-    filter << opts[:$filter] if opts[:$filter]
 
     # Fetch first page
     if last_synchronization.blank? || opts[:full_sync]
       Maestrano::Connector::Rails::ConnectorLogger.log('debug', organization, "entity=#{self.class.connec_entity_name}, fetching all data")
+      query_params[:$filter] = opts[:$filter] if opts[:$filter]
     else
       Maestrano::Connector::Rails::ConnectorLogger.log('debug', organization, "entity=#{self.class.connec_entity_name}, fetching data since #{last_synchronization.updated_at.iso8601}")
-      filter.unshift("updated_at gt '#{last_synchronization.updated_at.iso8601}'")
+      filter = "updated_at gt '#{last_synchronization.updated_at.iso8601}'"
+      filter += " and #{opts[:$filter]}" if opts[:$filter]
+      query_params[:$filter] = filter
     end
-    query_params[:$filter] = filter.join(' and ')
-
     response = client.get("/#{self.class.normalized_connec_entity_name}?#{query_params.to_query}")
     raise "No data received from Connec! when trying to fetch #{self.class.normalized_connec_entity_name}" unless response && !response.body.blank?
 

--- a/app/models/maestrano/connector/rails/organization.rb
+++ b/app/models/maestrano/connector/rails/organization.rb
@@ -59,5 +59,10 @@ module Maestrano::Connector::Rails
       self.instance_url = auth.credentials.instance_url
       self.save!
     end
+
+    def last_three_synchronizations_failed?
+      arr = self.synchronizations.last(3).map(&:is_error?)
+      arr.count == 3 && arr.uniq == [true]
+    end
   end
 end

--- a/app/models/maestrano/connector/rails/organization.rb
+++ b/app/models/maestrano/connector/rails/organization.rb
@@ -64,5 +64,9 @@ module Maestrano::Connector::Rails
       arr = self.synchronizations.last(3).map(&:is_error?)
       arr.count == 3 && arr.uniq == [true]
     end
+
+    def last_successful_synchronization
+      self.synchronizations.where(status: 'SUCCESS', partial: false).order(updated_at: :desc).first
+    end
   end
 end

--- a/db/migrate/20160427112250_add_inactive_to_idmaps.rb
+++ b/db/migrate/20160427112250_add_inactive_to_idmaps.rb
@@ -1,0 +1,5 @@
+class AddInactiveToIdmaps < ActiveRecord::Migration
+  def change
+    add_column :id_maps, :external_inactive, :boolean, default: false
+  end
+end

--- a/lib/generators/connector/templates/entity.rb
+++ b/lib/generators/connector/templates/entity.rb
@@ -46,4 +46,10 @@ class Maestrano::Connector::Rails::Entity
     # e.g entity['last_update']
   end
 
+  def self.inactive_from_external_entity_hash?(entity)
+    # TODO
+    # This method return true is entity is inactive in the external application
+    # e.g entity['status'] == 'INACTIVE'
+  end
+
 end

--- a/spec/controllers/connec_controller_spec.rb
+++ b/spec/controllers/connec_controller_spec.rb
@@ -70,8 +70,10 @@ describe Maestrano::ConnecController, type: :controller do
           let!(:organization) { create(:organization, uid: group_id, oauth_uid: 'lala', sync_enabled: true, synchronized_entities: {contact_and_lead: true}) }
 
           it 'process the data and push them' do
+            expect_any_instance_of(Entities::ContactAndLead).to receive(:before_sync)
             expect_any_instance_of(Entities::ContactAndLead).to receive(:consolidate_and_map_data).with({"Lead"=>[entity]}, {}, organization, {}).and_return({})
             expect_any_instance_of(Entities::ContactAndLead).to receive(:push_entities_to_external)
+            expect_any_instance_of(Entities::ContactAndLead).to receive(:after_sync)
             subject
           end
         end
@@ -135,8 +137,10 @@ describe Maestrano::ConnecController, type: :controller do
             let!(:organization) { create(:organization, uid: group_id, oauth_uid: 'lala', sync_enabled: true, synchronized_entities: {person: true}) }
 
             it 'process the data and push them' do
+              expect_any_instance_of(Entities::Person).to receive(:before_sync)
               expect_any_instance_of(Entities::Person).to receive(:consolidate_and_map_data).with([entity], [], organization, {}).and_return({})
               expect_any_instance_of(Entities::Person).to receive(:push_entities_to_external)
+              expect_any_instance_of(Entities::Person).to receive(:after_sync)
               subject
             end
           end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160215103120) do
+ActiveRecord::Schema.define(version: 20160427120963) do
 
   create_table "id_maps", force: :cascade do |t|
     t.string   "connec_id"
@@ -21,12 +21,13 @@ ActiveRecord::Schema.define(version: 20160215103120) do
     t.integer  "organization_id"
     t.datetime "last_push_to_connec"
     t.datetime "last_push_to_external"
-    t.datetime "created_at",                           null: false
-    t.datetime "updated_at",                           null: false
+    t.datetime "created_at",                            null: false
+    t.datetime "updated_at",                            null: false
     t.boolean  "to_connec",             default: true
     t.boolean  "to_external",           default: true
     t.string   "name"
     t.string   "message"
+    t.boolean  "external_inactive",     default: false
   end
 
   add_index "id_maps", ["connec_id", "connec_entity", "organization_id"], name: "idmap_connec_index"
@@ -40,6 +41,7 @@ ActiveRecord::Schema.define(version: 20160215103120) do
     t.string   "tenant"
     t.string   "oauth_provider"
     t.string   "oauth_uid"
+    t.string   "oauth_name"
     t.string   "oauth_token"
     t.string   "refresh_token"
     t.string   "instance_url"
@@ -78,6 +80,8 @@ ActiveRecord::Schema.define(version: 20160215103120) do
     t.string   "first_name"
     t.string   "last_name"
     t.string   "email"
+    t.string   "locale"
+    t.string   "timezone"
     t.string   "tenant"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/spec/jobs/push_to_connec_job_spec.rb
+++ b/spec/jobs/push_to_connec_job_spec.rb
@@ -60,7 +60,7 @@ describe Maestrano::Connector::Rails::PushToConnecJob do
       end
     end
 
-    describe 'with entities in syncrhonized entities' do
+    describe 'with entities in synchronized entities' do
 
       describe 'complex entity' do
         before { organization.update(synchronized_entities: {:"#{entity_name1}" => false, :"#{entity_name2}" => true})}
@@ -73,6 +73,12 @@ describe Maestrano::Connector::Rails::PushToConnecJob do
 
         it 'does not calls methods on the non complex entity' do
           expect_any_instance_of(Entities::Entity1).to_not receive(:consolidate_and_map_data)
+          subject
+        end
+
+        it 'calls before and after sync' do
+          expect_any_instance_of(Entities::Entity2).to receive(:before_sync)
+          expect_any_instance_of(Entities::Entity2).to receive(:after_sync)
           subject
         end
       end
@@ -89,6 +95,13 @@ describe Maestrano::Connector::Rails::PushToConnecJob do
         it 'does not calls methods on the complex entity' do
           allow_any_instance_of(Entities::Entity1).to receive(:consolidate_and_map_data).and_return({})
           expect_any_instance_of(Entities::Entity2).to_not receive(:consolidate_and_map_data)
+          subject
+        end
+
+        it 'calls before and after sync' do
+          allow_any_instance_of(Entities::Entity1).to receive(:consolidate_and_map_data).and_return({})
+          expect_any_instance_of(Entities::Entity1).to receive(:before_sync)
+          expect_any_instance_of(Entities::Entity1).to receive(:after_sync)
           subject
         end
       end

--- a/spec/models/entity_spec.rb
+++ b/spec/models/entity_spec.rb
@@ -196,7 +196,6 @@ describe Maestrano::Connector::Rails::Entity do
         end
 
         describe 'with response' do
-          let(:no_inactive_param) { {"$filter" => "status ne 'INACTIVE'"}.to_query }
           context 'for a singleton resource' do
             before {
               allow(client).to receive(:get).and_return(ActionDispatch::Response.new(200, {}, {person: []}.to_json, {}))
@@ -204,7 +203,7 @@ describe Maestrano::Connector::Rails::Entity do
             }
 
             it 'calls get with a singularize url' do
-              expect(client).to receive(:get).with("/#{connec_name.downcase}?#{no_inactive_param}")
+              expect(client).to receive(:get).with("/#{connec_name.downcase}?")
               subject.get_connec_entities(client, nil, organization)
             end
           end
@@ -216,49 +215,43 @@ describe Maestrano::Connector::Rails::Entity do
 
             context 'when opts[:full_sync] is true' do
               it 'performs a full get' do
-                expect(client).to receive(:get).with("/#{connec_name.downcase.pluralize}?#{no_inactive_param}")
+                expect(client).to receive(:get).with("/#{connec_name.downcase.pluralize}?")
                 subject.get_connec_entities(client, sync, organization, {full_sync: true})
               end
             end
 
             context 'when there is no last sync' do
               it 'performs a full get' do
-                expect(client).to receive(:get).with("/#{connec_name.downcase.pluralize}?#{no_inactive_param}")
+                expect(client).to receive(:get).with("/#{connec_name.downcase.pluralize}?")
                 subject.get_connec_entities(client, nil, organization)
               end
             end
 
             context 'when there is a last sync' do
               it 'performs a time limited get' do
-                uri_param = {"$filter" => "updated_at gt '#{sync.updated_at.iso8601}' and status ne 'INACTIVE'"}.to_query
+                uri_param = {"$filter" => "updated_at gt '#{sync.updated_at.iso8601}'"}.to_query
                 expect(client).to receive(:get).with("/#{connec_name.downcase.pluralize}?#{uri_param}")
                 subject.get_connec_entities(client, sync, organization)
               end
             end
 
             context 'with options' do
-              it 'supports filter option for full sync' do
-                uri_param = {'$filter'=>'status ne \'INACTIVE\' and code eq \'PEO12\''}.to_query
+              it 'support filter option for full sync' do
+                uri_param = {'$filter'=>'code eq \'PEO12\''}.to_query
                 expect(client).to receive(:get).with("/#{connec_name.downcase.pluralize}?#{uri_param}")
                 subject.get_connec_entities(client, sync, organization, {full_sync: true, :$filter => "code eq 'PEO12'"})
               end
 
-              it 'supports filter option for time limited sync' do
-                uri_param = {"$filter"=>"updated_at gt '#{sync.updated_at.iso8601}' and status ne 'INACTIVE' and code eq 'PEO12'"}.to_query
+              it 'support filter option for time limited sync' do
+                uri_param = {"$filter"=>"updated_at gt '#{sync.updated_at.iso8601}' and code eq 'PEO12'"}.to_query
                 expect(client).to receive(:get).with("/#{connec_name.downcase.pluralize}?#{uri_param}")
                 subject.get_connec_entities(client, sync, organization, {:$filter => "code eq 'PEO12'"})
               end
 
-              it 'supports orderby option for time limited sync' do
-                uri_param = {"$orderby"=>"name asc", "$filter"=>"updated_at gt '#{sync.updated_at.iso8601}' and status ne 'INACTIVE'"}.to_query
+              it 'support orderby option for time limited sync' do
+                uri_param = {"$orderby"=>"name asc", "$filter"=>"updated_at gt '#{sync.updated_at.iso8601}'"}.to_query
                 expect(client).to receive(:get).with("/#{connec_name.downcase.pluralize}?#{uri_param}")
                 subject.get_connec_entities(client, sync, organization, {:$orderby => "name asc"})
-              end
-
-              it 'supports include_inactive option for time limited sync' do
-                uri_param = {"$filter"=>"updated_at gt '#{sync.updated_at.iso8601}'"}.to_query
-                expect(client).to receive(:get).with("/#{connec_name.downcase.pluralize}?#{uri_param}")
-                subject.get_connec_entities(client, sync, organization, {include_inactive: true})
               end
             end
 

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -102,6 +102,36 @@ describe Maestrano::Connector::Rails::Organization do
     describe 'from_omniauth' do
       #TODO
     end
+
+    describe 'last_three_synchronizations_failed?' do
+      it 'returns true when last three syncs are failed' do
+        3.times do
+          subject.synchronizations.create(status: 'ERROR')
+        end
+        expect(subject.last_three_synchronizations_failed?).to be true
+      end
+
+      it 'returns false when on of the last three sync is success' do
+        subject.synchronizations.create(status: 'SUCCESS')
+        2.times do
+          subject.synchronizations.create(status: 'ERROR')
+        end
+
+        expect(subject.last_three_synchronizations_failed?).to be false
+      end
+
+      it 'returns false when no sync' do
+        expect(subject.last_three_synchronizations_failed?).to be false
+      end
+
+      it 'returns false when less than three sync' do
+        2.times do
+          subject.synchronizations.create(status: 'ERROR')
+        end
+        
+        expect(subject.last_three_synchronizations_failed?).to be false
+      end
+    end
   end
 
 end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -132,6 +132,17 @@ describe Maestrano::Connector::Rails::Organization do
         expect(subject.last_three_synchronizations_failed?).to be false
       end
     end
+
+    describe 'last_successful_synchronization' do
+      let!(:running_sync) { create(:synchronization, organization: subject, status: 'RUNNING') }
+      let!(:failed_sync) { create(:synchronization, organization: subject, status: 'ERROR') }
+      let!(:success_sync) { create(:synchronization, organization: subject, status: 'SUCCESS') }
+      let!(:success_sync2) { create(:synchronization, organization: subject, status: 'SUCCESS', updated_at: 3.hours.ago) }
+      let!(:partial) { create(:synchronization, organization: subject, status: 'SUCCESS', partial: true) }
+
+      it { expect(subject.last_successful_synchronization).to eql(success_sync) }
+    end
   end
+
 
 end


### PR DESCRIPTION
@x4d3 Can you have a look?

@x4d3 @BrunoChauvet Not sure about the last one. What's the intended way for inactive object? Should we let each connector map inactive to the external api inactive field? what if it's not supported?