### PR TITLE
Retro-compatibility case for string ids coming from connec

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,5 +25,6 @@ RSpec.configure do |config|
     allow(Maestrano::Connector::Rails::External).to receive(:external_name).and_return('External app')
     allow(Maestrano::Connector::Rails::External).to receive(:get_client).and_return(Object.new)
     allow(Maestrano::Connector::Rails::External).to receive(:entities_list).and_return(%w(entity1 entity2))
+    Rails.cache.clear
   end
 end


### PR DESCRIPTION
Also fixes connec version so that the cache is scoped by tenant.

@BrunoChauvet That should fit the first part of what've discussed. I'll update impacted connectors with that so that they expect an array for all references but still work if it's a string.

I'll look tomorrow into solving the line id issue