### PR TITLE
[MNOE-179] Return current synchronisation status for all calls

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,6 +20,9 @@ Style/CollectionMethods:
 Metrics/LineLength:
   Max: 320
 
+Metrics/MethodLength:
+  Max: 50
+
 Style/IndentationConsistency:
   EnforcedStyle: rails
 

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -102,14 +102,6 @@ Style/EmptyLinesAroundModuleBody:
 Style/FrozenStringLiteralComment:
   Enabled: false
 
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, SupportedStyles.
-# SupportedStyles: predicate, comparison
-Style/NumericPredicate:
-  Exclude:
-    - 'app/models/maestrano/connector/rails/organization.rb'
-
 # Offense count: 3
 # Configuration parameters: NamePrefix, NamePrefixBlacklist, NameWhitelist.
 # NamePrefix: is_, has_, have_

--- a/app/controllers/maestrano/synchronizations_controller.rb
+++ b/app/controllers/maestrano/synchronizations_controller.rb
@@ -3,23 +3,11 @@ class Maestrano::SynchronizationsController < Maestrano::Rails::WebHookControlle
     tenant = params[:tenant]
     uid = params[:id]
     organization = Maestrano::Connector::Rails::Organization.find_by_uid_and_tenant(uid, tenant)
-    return render json: {errors: [{message: "Organization not found", code: 404}]}, status: :not_found unless organization
+    return render json: {errors: [{message: 'Organization not found', code: 404}]}, status: :not_found unless organization
 
-    h = {
-      group_id: organization.uid,
-      sync_enabled: organization.sync_enabled
-    }
+    status = organization_status organization
 
-    last_sync = organization.synchronizations.last
-    if last_sync
-      h.merge!(
-        status: last_sync.status,
-        message: last_sync.message,
-        updated_at: last_sync.updated_at
-      )
-    end
-
-    render json: h
+    render_organization_sync(organization, status, 200)
   end
 
   def create
@@ -27,21 +15,52 @@ class Maestrano::SynchronizationsController < Maestrano::Rails::WebHookControlle
     uid = params[:group_id]
     opts = params[:opts] || {}
     organization = Maestrano::Connector::Rails::Organization.find_by_uid_and_tenant(uid, tenant)
-    return render json: {errors: [{message: "Organization not found", code: 404}]}, status: :not_found unless organization
+    return render json: {errors: [{message: 'Organization not found', code: 404}]}, status: :not_found unless organization
 
-    Maestrano::Connector::Rails::SynchronizationJob.perform_later(organization, opts.with_indifferent_access)
-    head :created
+    status = Maestrano::Connector::Rails::SynchronizationJob.find_running_job(organization.id) ? 'RUNNING' : 'ENQUEUED'
+
+
+    Maestrano::Connector::Rails::SynchronizationJob.perform_later(organization.id, opts.with_indifferent_access) unless Maestrano::Connector::Rails::SynchronizationJob.enqueued?(organization.id)
+    render_organization_sync(organization, status, 201)
   end
 
   def toggle_sync
     tenant = params[:tenant]
     uid = params[:group_id]
     organization = Maestrano::Connector::Rails::Organization.find_by_uid_and_tenant(uid, tenant)
-    return render json: {errors: [{message: "Organization not found", code: 404}]}, status: :not_found unless organization
+    return render json: {errors: [{message: 'Organization not found', code: 404}]}, status: :not_found unless organization
 
     organization.toggle(:sync_enabled)
     organization.save
-
-    render json: {sync_enabled: organization.sync_enabled}
+    status = organization_status organization
+    render_organization_sync(organization, status, 200)
   end
+
+  private
+
+    def render_organization_sync(organization, status, code)
+      h = {
+        group_id: organization.uid,
+        sync_enabled: organization.sync_enabled,
+        status: status
+      }
+      last_sync = organization.synchronizations.last
+      if last_sync
+        h[:message] = last_sync.message
+        h[:updated_at] = last_sync.updated_at
+      end
+
+      render json: h, status: code
+    end
+
+    def organization_status(organization)
+      last_sync = organization.synchronizations.last
+      if Maestrano::Connector::Rails::SynchronizationJob.find_running_job(organization.id)
+        'RUNNING'
+      elsif Maestrano::Connector::Rails::SynchronizationJob.find_job(organization.id)
+        'ENQUEUED'
+      else
+        last_sync ? last_sync.status : 'DISABLED'
+      end
+    end
 end

--- a/app/jobs/maestrano/connector/rails/all_synchronizations_job.rb
+++ b/app/jobs/maestrano/connector/rails/all_synchronizations_job.rb
@@ -6,7 +6,7 @@ module Maestrano::Connector::Rails
     def perform(name = nil, count = nil)
       Maestrano::Connector::Rails::Organization.where.not(oauth_provider: nil, encrypted_oauth_token: nil).each do |o|
         next unless [true, 1].include?(o.sync_enabled)
-        Maestrano::Connector::Rails::SynchronizationJob.perform_later(o, {})
+        Maestrano::Connector::Rails::SynchronizationJob.perform_later(o.id, {})
       end
     end
   end

--- a/app/jobs/maestrano/connector/rails/synchronization_job.rb
+++ b/app/jobs/maestrano/connector/rails/synchronization_job.rb
@@ -7,9 +7,9 @@ module Maestrano::Connector::Rails
     #  * :only_entities => [person, tasks_list]
     #  * :full_sync => true  synchronization is performed without date filtering
     #  * :connec_preemption => true|false : preemption is always|never given to connec in case of conflict (if not set, the most recently updated entity is kept)
-    def perform(organization, opts = {})
-      return unless organization.sync_enabled
-
+    def perform(organization_id, opts = {})
+      organization = Maestrano::Connector::Rails::Organization.find(organization_id)
+      return unless organization && organization.sync_enabled
       # Check if previous synchronization is still running
       if Synchronization.where(organization_id: organization.id, status: 'RUNNING').where(created_at: (30.minutes.ago..Time.now)).exists?
         ConnectorLogger.log('info', organization, 'Synchronization skipped: Previous synchronization is still running')
@@ -105,6 +105,21 @@ module Maestrano::Connector::Rails
       end
     end
 
+    def self.enqueued?(organization_id)
+      SynchronizationJob.find_job(organization_id).present? || SynchronizationJob.find_running_job(organization_id).present?
+    end
+
+    def self.find_job(organization_id)
+      queue = Sidekiq::Queue.new(:default)
+      queue.select { |job| organization_id == job.item['args'][0]['arguments'].first }.first
+    end
+
+    def self.find_running_job(organization_id)
+      Sidekiq::Workers.new.find { |_, _, work| work['queue'] == 'sync_job' && work['payload']['args'][0]['arguments'] == organization_id }
+    rescue
+      nil
+    end
+
     private
 
       def instanciate_entity(entity_name, organization, connec_client, external_client, opts)
@@ -120,7 +135,7 @@ module Maestrano::Connector::Rails
         entity_instance.push_entities_to_external(mapped_entities[:connec_entities])
         entity_instance.push_entities_to_connec(mapped_entities[:external_entities])
         entity_instance.after_sync(last_synchronization_date)
-        
+
         entity_instance.class.count_and_first(external ? external_entities : connec_entities)
       end
   end

--- a/app/jobs/maestrano/connector/rails/synchronization_job.rb
+++ b/app/jobs/maestrano/connector/rails/synchronization_job.rb
@@ -111,11 +111,15 @@ module Maestrano::Connector::Rails
 
     def self.find_job(organization_id)
       queue = Sidekiq::Queue.new(:default)
-      queue.select { |job| organization_id == job.item['args'][0]['arguments'].first }.first
+      queue.find do |job|
+        organization_id == job.item['args'][0]['arguments'].first
+      end
     end
 
     def self.find_running_job(organization_id)
-      Sidekiq::Workers.new.find { |_, _, work| work['queue'] == 'sync_job' && work['payload']['args'][0]['arguments'] == organization_id }
+      Sidekiq::Workers.new.find do |_, _, work|
+        work['queue'] == 'default' && work['payload']['args'][0]['arguments'].first == organization_id
+      end
     rescue
       nil
     end

--- a/lib/generators/connector/templates/home_controller.rb
+++ b/lib/generators/connector/templates/home_controller.rb
@@ -23,7 +23,7 @@ class HomeController < ApplicationController
 
   def synchronize
     return redirect_to(:back) unless is_admin
-    Maestrano::Connector::Rails::SynchronizationJob.perform_later(current_organization, (params['opts'] || {}).merge(forced: true))
+    Maestrano::Connector::Rails::SynchronizationJob.perform_later(current_organization.id, (params['opts'] || {}).merge(forced: true))
     flash[:info] = 'Synchronization requested'
     redirect_to(:back)
   end
@@ -35,7 +35,7 @@ class HomeController < ApplicationController
   private
 
     def start_synchronization(old_sync_state, organization)
-      Maestrano::Connector::Rails::SynchronizationJob.perform_later(organization, {})
+      Maestrano::Connector::Rails::SynchronizationJob.perform_later(organization.id, {})
       flash[:info] = 'Congrats, you\'re all set up! Your data are now being synced'
     end
 end

--- a/lib/generators/connector/templates/home_controller_spec.rb
+++ b/lib/generators/connector/templates/home_controller_spec.rb
@@ -87,7 +87,7 @@ describe HomeController, type: :controller do
         subject { post :synchronize, opts: {'opts' => 'some_opts'} }
 
         it 'calls perform_later with opts' do
-          expect(Maestrano::Connector::Rails::SynchronizationJob).to receive(:perform_later).with(organization, 'opts' => 'some_opts', forced: true)
+          expect(Maestrano::Connector::Rails::SynchronizationJob).to receive(:perform_later).with(organization.id, 'opts' => 'some_opts', forced: true)
           subject
         end
       end
@@ -96,7 +96,7 @@ describe HomeController, type: :controller do
         subject { post :synchronize }
 
         it 'calls perform_later with empty opts hash' do
-          expect(Maestrano::Connector::Rails::SynchronizationJob).to receive(:perform_later).with(organization, forced: true)
+          expect(Maestrano::Connector::Rails::SynchronizationJob).to receive(:perform_later).with(organization.id, forced: true)
           subject
         end
       end

--- a/spec/controllers/synchronizations_controller_spec.rb
+++ b/spec/controllers/synchronizations_controller_spec.rb
@@ -61,6 +61,7 @@ describe Maestrano::SynchronizationsController, type: :controller do
               JSON.parse({
                 group_id: organization.uid,
                 sync_enabled: organization.sync_enabled,
+                status: 'DISABLED'
               }.to_json)
             )
           end
@@ -78,7 +79,7 @@ describe Maestrano::SynchronizationsController, type: :controller do
                 sync_enabled: organization.sync_enabled,
                 status: sync2.status,
                 message: sync2.message,
-                updated_at: sync2.updated_at   
+                updated_at: sync2.updated_at
               }.to_json)
             )
           end
@@ -135,7 +136,7 @@ describe Maestrano::SynchronizationsController, type: :controller do
         end
 
         it 'queues a sync' do
-          expect(Maestrano::Connector::Rails::SynchronizationJob).to receive(:perform_later).with(organization, opts)
+          expect(Maestrano::Connector::Rails::SynchronizationJob).to receive(:perform_later).with(organization.id, opts)
           subject
         end
       end

--- a/spec/jobs/all_synchronizations_job_spec.rb
+++ b/spec/jobs/all_synchronizations_job_spec.rb
@@ -14,9 +14,9 @@ describe Maestrano::Connector::Rails::AllSynchronizationsJob do
 
   describe 'perform' do
     it 'does not calls sync entity' do
-      expect(Maestrano::Connector::Rails::SynchronizationJob).to_not receive(:perform_later).with(organization_not_linked, anything)
-      expect(Maestrano::Connector::Rails::SynchronizationJob).to_not receive(:perform_later).with(organization_not_active, anything)
-      expect(Maestrano::Connector::Rails::SynchronizationJob).to receive(:perform_later).with(organization_to_process, anything)
+      expect(Maestrano::Connector::Rails::SynchronizationJob).to_not receive(:perform_later).with(organization_not_linked.id, anything)
+      expect(Maestrano::Connector::Rails::SynchronizationJob).to_not receive(:perform_later).with(organization_not_active.id, anything)
+      expect(Maestrano::Connector::Rails::SynchronizationJob).to receive(:perform_later).with(organization_to_process.id, anything)
 
       subject
     end


### PR DESCRIPTION
Breaking change: Maestrano::Connector::Rails::SynchronizationJob.perform_later is now taking an organization_id instead of an organization