### PR TITLE
[APPINT-309] Prevent the same account's connection to multiple organisation

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -25,6 +25,10 @@ Jeweler::Tasks.new do |gem|
 end
 Jeweler::RubygemsDotOrgTasks.new
 
+# Rubocop
+require 'rubocop/rake_task'
+RuboCop::RakeTask.new
+
 APP_RAKEFILE = File.expand_path('../spec/dummy/Rakefile', __FILE__)
 load 'rails/tasks/engine.rake'
 
@@ -34,4 +38,4 @@ require 'rspec/core/rake_task'
 desc 'Run all specs in spec directory (excluding plugin specs)'
 RSpec::Core::RakeTask.new(spec: 'app:db:test:prepare')
 
-task default: :spec
+task default: [:spec, :rubocop]

--- a/app/models/maestrano/connector/rails/organization.rb
+++ b/app/models/maestrano/connector/rails/organization.rb
@@ -38,6 +38,7 @@ module Maestrano::Connector::Rails
     validates :name, presence: true
     validates :tenant, presence: true
     validates :uid, uniqueness: {scope: :tenant}
+    validates :oauth_uid, uniqueness: true
 
     #===================================
     # Serialized field

--- a/db/migrate/20161011005751_add_unique_index_on_organization_oauth_uid.rb
+++ b/db/migrate/20161011005751_add_unique_index_on_organization_oauth_uid.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexOnOrganizationOauthUid < ActiveRecord::Migration
+  def change
+    add_index :organizations, :oauth_uid, unique: true
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -8,7 +8,7 @@ FactoryGirl.define do
     name 'My company'
     tenant 'default'
     sequence(:uid) { |n| "cld-11#{n}" }
-    oauth_uid 'sfuiy765'
+    sequence(:oauth_uid) { |n| "00#{n}" }
     oauth_provider 'this_app'
   end
 

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -25,6 +25,12 @@ describe Maestrano::Connector::Rails::Organization do
       expect(subject.synchronized_entities).to include(entities_list.first.to_sym)
       expect(subject.synchronized_entities).to include(entities_list.last.to_sym)
     end
+
+    it 'does not allow organizations with the same oauth UID' do
+      organization1 = create(:organization, oauth_provider: 'myapp', oauth_uid: 'ABC')
+      organization2 = build(:organization, oauth_provider: 'myapp', oauth_uid: 'ABC')
+      expect(organization2).not_to be_valid
+    end
   end
 
   describe "instance methods" do
@@ -129,7 +135,7 @@ describe Maestrano::Connector::Rails::Organization do
         2.times do
           subject.synchronizations.create(status: 'ERROR')
         end
-        
+
         expect(subject.last_three_synchronizations_failed?).to be false
       end
     end
@@ -146,7 +152,7 @@ describe Maestrano::Connector::Rails::Organization do
 
     describe 'last_synchronization_date' do
       let(:date) { 2.days.ago }
-      
+
       context 'with date_filtering_limit' do
         before {
           subject.date_filtering_limit = date


### PR DESCRIPTION
- Make the Organization `oauth_uid` unique
- Add rubocop to default rake task