### PR TITLE
Add method to reset the list of entities shared

### DIFF
--- a/app/models/maestrano/connector/rails/organization.rb
+++ b/app/models/maestrano/connector/rails/organization.rb
@@ -114,5 +114,11 @@ module Maestrano::Connector::Rails
     def last_synchronization_date
       last_successful_synchronization&.updated_at || date_filtering_limit
     end
+
+    def reset_synchronized_entities
+      synchronized_entities.slice!(*External.entities_list.map(&:to_sym))
+      External.entities_list.each { |entity| synchronized_entities[entity.to_sym] ||= false }
+      save
+    end
   end
 end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -207,7 +207,22 @@ describe Maestrano::Connector::Rails::Organization do
         it { expect(subject.last_synchronization_date).to eql(nil) }
       end
     end
+
+    describe '#reset_synchronized_entities' do
+      let(:organization) { create(:organization, synchronized_entities: {entity1: true, entity2: false, tomatoes: true}) }
+      subject { organization.reset_synchronized_entities }
+
+      it 'keeps only the known entities' do
+        subject
+        expect(organization.synchronized_entities).to eql(entity1: true, entity2: false)
+      end
+
+      it 'adds missing entities' do
+        organization.update_attributes(synchronized_entities: {entity1: true, tomatoes: true})
+
+        subject
+        expect(organization.synchronized_entities).to eql(entity1: true, entity2: false)
+      end
+    end
   end
-
-
 end


### PR DESCRIPTION
This will allow running migrations to reset the list of entities shared when we add/remove entities mapped

```ruby
Maestrano::Connector::Rails::Organization.all.each { |o| o.reset_synchronized_entities }
```