### PR TITLE
Lower case entities names in connec webhook

### DIFF
--- a/app/controllers/maestrano/connec_controller.rb
+++ b/app/controllers/maestrano/connec_controller.rb
@@ -58,12 +58,13 @@ class Maestrano::ConnecController < Maestrano::Rails::WebHookController
     end
 
     def find_entity_class(entity_name)
+      parametrised_entity_name = entity_name.parameterize('_')
       Maestrano::Connector::Rails::External.entities_list.each do |entity_name_from_list|
         clazz = "Entities::#{entity_name_from_list.singularize.titleize.split.join}".constantize
         if clazz.methods.include?('connec_entities_names'.to_sym)
           formatted_entities_names = clazz.connec_entities_names.map { |n| n.parameterize('_').pluralize }
-          return {class: clazz, is_complex: true, name: entity_name_from_list} if formatted_entities_names.include?(entity_name)
-        elsif clazz.methods.include?('connec_entity_name'.to_sym) && clazz.normalized_connec_entity_name == entity_name
+          return {class: clazz, is_complex: true, name: entity_name_from_list} if formatted_entities_names.include?(parametrised_entity_name)
+        elsif clazz.methods.include?('connec_entity_name'.to_sym) && clazz.normalized_connec_entity_name == parametrised_entity_name
           return {class: clazz, is_complex: false, name: entity_name_from_list}
         end
       end

--- a/app/controllers/maestrano/connec_controller.rb
+++ b/app/controllers/maestrano/connec_controller.rb
@@ -58,7 +58,7 @@ class Maestrano::ConnecController < Maestrano::Rails::WebHookController
     end
 
     def find_entity_class(entity_name)
-      parametrised_entity_name = entity_name.parameterize('_')
+      parametrised_entity_name = entity_name.parameterize('_').pluralize
       Maestrano::Connector::Rails::External.entities_list.each do |entity_name_from_list|
         clazz = "Entities::#{entity_name_from_list.singularize.titleize.split.join}".constantize
         if clazz.methods.include?('connec_entities_names'.to_sym)

--- a/spec/controllers/connec_controller_spec.rb
+++ b/spec/controllers/connec_controller_spec.rb
@@ -158,6 +158,19 @@ describe Maestrano::ConnecController, type: :controller do
               expect_any_instance_of(Entities::Person).to receive(:after_sync)
               subject
             end
+
+            context 'with different entity name case and singular' do
+              let(:notifications) { {'Person' => [entity]} }
+
+              it 'process the data and push them' do
+                expect_any_instance_of(Entities::Person).to receive(:before_sync)
+                expect_any_instance_of(Entities::Person).to receive(:filter_connec_entities).and_return([entity])
+                expect_any_instance_of(Entities::Person).to receive(:consolidate_and_map_data).with([entity], []).and_return({})
+                expect_any_instance_of(Entities::Person).to receive(:push_entities_to_external)
+                expect_any_instance_of(Entities::Person).to receive(:after_sync)
+                subject
+              end
+            end
           end
         end
       end


### PR DESCRIPTION
This ensures that we compare entity names in the same format (upper/lower case)