### PR TITLE
Add ability to switch off updates of a field

### DIFF
--- a/app/models/maestrano/connector/rails/concerns/entity.rb
+++ b/app/models/maestrano/connector/rails/concerns/entity.rb
@@ -135,6 +135,10 @@ module Maestrano::Connector::Rails::Concerns::Entity
       true
     end
 
+    def currency_check_field
+      nil
+    end
+
     # ----------------------------------------------
     #                 Helper methods
     # ----------------------------------------------
@@ -260,6 +264,14 @@ module Maestrano::Connector::Rails::Concerns::Entity
     # As we're doing only POST, we use the idmaps to filter out updates
     unless self.class.can_update_connec?
       mapped_external_entities_with_idmaps.select! { |mapped_external_entity_with_idmap| !mapped_external_entity_with_idmap[:idmap].connec_id }
+    end
+
+    if self.class.currency_check_field
+      mapped_external_entities_with_idmaps.each { |mapped_external_entity_with_idmap|
+        id_map = mapped_external_entity_with_idmap[:idmap]
+        next unless id_map&.metadata&.dig(:ignore_currency_update)
+        mapped_external_entity_with_idmap[:entity].delete(self.class.currency_check_field)
+      }
     end
 
     proc = ->(mapped_external_entity_with_idmap) { batch_op('post', mapped_external_entity_with_idmap[:entity], nil, self.class.normalize_connec_entity_name(connec_entity_name)) }

--- a/app/models/maestrano/connector/rails/concerns/sub_entity_base.rb
+++ b/app/models/maestrano/connector/rails/concerns/sub_entity_base.rb
@@ -49,14 +49,15 @@ module Maestrano::Connector::Rails::Concerns::SubEntityBase
     end
   end
 
-  def map_to(name, entity, first_time_mapped = nil)
+  def map_to(name, entity, idmap = nil)
+    first_time_mapped = self.class.external? ? idmap&.last_push_to_connec.nil? : idmap&.last_push_to_external.nil?
     mapper = first_time_mapped ? self.class.creation_mapper_classes[name] : self.class.mapper_classes[name]
     raise "Impossible mapping from #{self.class.entity_name} to #{name}" unless mapper
 
     if self.class.external?
       map_to_connec_helper(entity, mapper, self.class.references[name] || [])
     else
-      map_to_external_helper(entity, mapper)
+      map_to_external_helper(entity.merge(idmap: idmap), mapper)
     end
   end
 

--- a/app/models/maestrano/connector/rails/id_map.rb
+++ b/app/models/maestrano/connector/rails/id_map.rb
@@ -1,5 +1,6 @@
 module Maestrano::Connector::Rails
   class IdMap < ActiveRecord::Base
     belongs_to :organization
+    serialize :metadata, Hash
   end
 end

--- a/app/models/maestrano/connector/rails/services/data_consolidator.rb
+++ b/app/models/maestrano/connector/rails/services/data_consolidator.rb
@@ -34,7 +34,7 @@ module Maestrano::Connector::Rails::Services
         entity = unfold_hash[:entity]
         idmap.update(name: @current_entity.class.object_name_from_connec_entity_hash(entity), connec_id: unfold_hash[:connec_id])
         idmap.update(external_id: @current_entity.class.id_from_external_entity_hash(external_entities.first)) unless external_entities.empty?
-        return {connec_entities: [{entity: @current_entity.map_to_external(entity), idmap: idmap, id_refs_only_connec_entity: {}}], external_entities: []}
+        return {connec_entities: [{entity: @current_entity.map_to_external(entity.merge(idmap: idmap)), idmap: idmap, id_refs_only_connec_entity: {}}], external_entities: []}
       end
     end
 
@@ -109,7 +109,7 @@ module Maestrano::Connector::Rails::Services
 
     def map_external_entity_with_idmap(external_entity, connec_entity_name, idmap)
       entity = if @is_a_subentity
-                 @current_entity.map_to(connec_entity_name, external_entity, idmap.last_push_to_connec.nil?)
+                 @current_entity.map_to(connec_entity_name, external_entity, idmap)
                else
                  @current_entity.map_to_connec(external_entity, idmap.last_push_to_connec.nil?)
                end
@@ -118,9 +118,9 @@ module Maestrano::Connector::Rails::Services
 
     def map_connec_entity_with_idmap(connec_entity, external_entity_name, idmap, id_refs_only_connec_entity)
       entity = if @is_a_subentity
-                 @current_entity.map_to(external_entity_name, connec_entity, idmap.last_push_to_external.nil?)
+                 @current_entity.map_to(external_entity_name, connec_entity, idmap)
                else
-                 @current_entity.map_to_external(connec_entity, idmap.last_push_to_external.nil?)
+                 @current_entity.map_to_external(connec_entity.merge(idmap: idmap), idmap.last_push_to_external.nil?)
                end
       {entity: entity, idmap: idmap, id_refs_only_connec_entity: id_refs_only_connec_entity}
     end

--- a/db/migrate/20170315032224_add_metadata_to_id_map.rb
+++ b/db/migrate/20170315032224_add_metadata_to_id_map.rb
@@ -1,0 +1,5 @@
+class AddMetadataToIdMap < ActiveRecord::Migration
+  def change
+  	add_column :id_maps, :metadata, :text
+  end
+end

--- a/lib/maestrano_connector_rails/factories.rb
+++ b/lib/maestrano_connector_rails/factories.rb
@@ -25,6 +25,7 @@ FactoryGirl.define do
     last_push_to_external 2.days.ago
     last_push_to_connec 1.day.ago
     association :organization
+    metadata {}
   end
 
   factory :synchronization, class: Maestrano::Connector::Rails::Synchronization do

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -28,6 +28,7 @@ ActiveRecord::Schema.define(version: 20170202033323) do
     t.string   "name"
     t.string   "message"
     t.boolean  "external_inactive",     default: false
+    t.text     "metadata"
   end
 
   add_index "id_maps", ["connec_id", "connec_entity", "organization_id"], name: "idmap_connec_index"

--- a/spec/models/complex_entity_spec.rb
+++ b/spec/models/complex_entity_spec.rb
@@ -236,7 +236,7 @@ describe Maestrano::Connector::Rails::ComplexEntity do
             allow(subject.class).to receive(:external_entities_names).and_return(['ext1'])
             allow(Entities::SubEntities::ScE1).to receive(:external?).and_return(false)
             allow(Entities::SubEntities::ScE1).to receive(:entity_name).and_return(connec_name)
-            allow_any_instance_of(Entities::SubEntities::ScE1).to receive(:map_to).with(external_name, entity, first_time_synch).and_return(mapped_entity)
+            allow_any_instance_of(Entities::SubEntities::ScE1).to receive(:map_to).and_return(mapped_entity)
             allow(Entities::SubEntities::ScE1).to receive(:object_name_from_connec_entity_hash).and_return(human_name)
             allow(Maestrano::Connector::Rails::ConnecHelper).to receive(:unfold_references).and_return({entity: entity, connec_id: connec_id, id_refs_only_connec_entity: id_refs_only_connec_entity})
           end

--- a/spec/models/sub_entity_base_spec.rb
+++ b/spec/models/sub_entity_base_spec.rb
@@ -111,7 +111,7 @@ describe Maestrano::Connector::Rails::SubEntityBase do
         it 'calls the creation_mapper_classes that delegates to the mapper_classes denormalize when passed true as a third argument' do
           expect(subject.class).to receive(:creation_mapper_classes).and_call_original
           expect(AMapper).to receive(:denormalize).with({}, subject.instance_values).and_return({})
-          subject.map_to('Name', {}, true)
+          subject.map_to('Name', {}, nil)
         end
 
         context 'when no refs' do
@@ -140,14 +140,14 @@ describe Maestrano::Connector::Rails::SubEntityBase do
         end
 
         it 'calls the mapper normalize' do
-          expect(AMapper).to receive(:normalize).with({}, subject.instance_values).and_return({})
+          expect(AMapper).to receive(:normalize).with({idmap: nil}, subject.instance_values).and_return({})
           subject.map_to('Name', {})
         end
 
         it 'calls the creation_mapper_classes that delegates to the mapper_classes normalize when passed true as a third argument' do
           expect(subject.class).to receive(:creation_mapper_classes).and_call_original
-          expect(AMapper).to receive(:normalize).with({}, subject.instance_values).and_return({})
-          subject.map_to('Name', {}, true)
+          expect(AMapper).to receive(:normalize).with({idmap: nil}, subject.instance_values).and_return({})
+          subject.map_to('Name', {}, nil)
         end
       end
     end


### PR DESCRIPTION
That way, we can update the idmap metadata in after_normalize like this:
```ruby
idmap = input['idmap']
idmap.update_attributes(metadata:idmap.metadata.merge(ignore_currency_update: true)) if idmap
```
Then, by updating the currency_check_field, for any data being pushed to Connnec!, this field won't be sent

Will make the rule 3.2.1 here: [Applications integration business rules](https://maestrano.atlassian.net/wiki/display/EN/Applications+integration+business+rules) much easier to apply.