### PR TITLE
Set version to 2.1.0 + update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 2.1.0
+
+### Features
+* If there are no previous synchronizations and the synchronization fails, the last_synchronization_date is
+  set to the creation date of the failed sync (instead of resetting to the date_filtering_limit)
+* Organization and User can now be overridden in the connectors
+* Updates to layout of generated connectors
+* Option to push/pull disable for a specific Organization
+* Optional methods to limit currency updates 
+
+### Migration guide
+* Please refer to this document in the
+[Maestrano Guides](https://maestrano.atlassian.net/wiki/spaces/DEV/pages/102336339/Migration+Guides)
+
 ## 2.0.0
 
 ### Features

--- a/lib/maestrano/connector/rails/version.rb
+++ b/lib/maestrano/connector/rails/version.rb
@@ -1,7 +1,7 @@
 module Maestrano
   module Connector
     module Rails
-      VERSION = '2.0.2.pre.RC12'.freeze
+      VERSION = '2.1.0'.freeze
     end
   end
 end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -196,7 +196,7 @@ describe Maestrano::Connector::Rails::Organization do
         before { subject.date_filtering_limit = date}
 
         it 'returns the sync date' do
-          expect(subject.last_synchronization_date.to_date).to eql(success_sync.updated_at.to_date)
+          expect(subject.last_synchronization_date.to_date).to be_within(1.second).of(success_sync.updated_at.to_date)
         end
       end
 


### PR DESCRIPTION
- Use be_within matcher to avoid milliseconds runding differencies