### PR TITLE
Fix a bug where historical data present and first sync fails

### DIFF
--- a/app/models/maestrano/connector/rails/concerns/organization.rb
+++ b/app/models/maestrano/connector/rails/concerns/organization.rb
@@ -121,7 +121,11 @@ module Maestrano::Connector::Rails::Concerns::Organization
   end
 
   def last_synchronization_date
-    last_successful_synchronization&.updated_at || synchronizations&.first&.created_at || date_filtering_limit
+    last_successful_synchronization&.updated_at || historical_not_enabled_and_not_first_sync || date_filtering_limit
+  end
+
+  def historical_not_enabled_and_not_first_sync
+    !self.historical_data && synchronizations&.first&.created_at
   end
 
   def reset_synchronized_entities(default = false)

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -204,11 +204,18 @@ describe Maestrano::Connector::Rails::Organization do
         it { expect(subject.last_synchronization_date).to eql(nil) }
       end
 
-      context 'when the synchronization fails and there are no previous successful syncs' do
+      context 'when the synchronization fails and there are no previous successful syncs - No Historical Data' do
         let!(:failed_sync) { create(:synchronization, organization: subject, status: 'ERROR', created_at: 1.minute.ago) }
         before { subject.date_filtering_limit = date}
 
         it { expect(subject.last_synchronization_date).to be_within(1.second).of(failed_sync.created_at) }
+      end
+
+      context 'when the synchronization fails and there are no previous successful syncs - Historical Data' do
+        let!(:failed_sync) { create(:synchronization, organization: subject, status: 'ERROR', created_at: 1.minute.ago) }
+        before { subject.historical_data = true}
+
+        it { expect(subject.last_synchronization_date).to be_nil }
       end
     end
 


### PR DESCRIPTION
- If the user selects historical data and the first sync has a state of 'ERROR' we want the next sync to have `last_synchronization_date = nil`