### PR TITLE
Update organization initializer handling of synchronized entities

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -62,13 +62,6 @@ Performance/FlatMap:
   Exclude:
     - 'app/models/maestrano/connector/rails/concerns/complex_entity.rb'
 
-# Offense count: 2
-# Cop supports --auto-correct.
-# Configuration parameters: AutoCorrect.
-Performance/HashEachMethods:
-  Exclude:
-    - 'app/resources/maestrano/api/base_resource.rb'
-
 # Offense count: 1
 # Cop supports --auto-correct.
 # Configuration parameters: Whitelist.

--- a/Rakefile
+++ b/Rakefile
@@ -8,7 +8,7 @@ require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 require 'rubocop/rake_task'
 
-APP_RAKEFILE = File.expand_path('../spec/dummy/Rakefile', __FILE__)
+APP_RAKEFILE = File.expand_path('spec/dummy/Rakefile', __dir__)
 load 'rails/tasks/engine.rake'
 
 RuboCop::RakeTask.new

--- a/app/models/maestrano/connector/rails/concerns/organization.rb
+++ b/app/models/maestrano/connector/rails/concerns/organization.rb
@@ -54,7 +54,9 @@ module Maestrano::Connector::Rails::Concerns::Organization
     self.synchronized_entities = {}
     Maestrano::Connector::Rails::External.entities_list.each do |entity|
       begin
-        clazz = "Entities::#{entity.to_s.titleize.split.join}".constantize
+        # Transform entity name from entities_list to class name
+        # ex. :item => Entities::Item
+        clazz = "Entities::#{entity.to_s.titleize.tr(' ', '')}".constantize
       rescue
         clazz = nil
       end
@@ -71,7 +73,9 @@ module Maestrano::Connector::Rails::Concerns::Organization
     result = {}
     synchronized_entities.each do |entity, hash|
       begin
-        clazz = "Entities::#{entity.to_s.titleize.split.join}".constantize
+        # Transform entity name from entities_list to class name
+        # ex. :item => Entities::Item
+        clazz = "Entities::#{entity.to_s.titleize.tr(' ', '')}".constantize
       rescue
         next
       end

--- a/app/models/maestrano/connector/rails/concerns/synchronization.rb
+++ b/app/models/maestrano/connector/rails/concerns/synchronization.rb
@@ -36,15 +36,15 @@ module Maestrano::Connector::Rails::Concerns::Synchronization
   end
 
   def mark_as_success
-    update_attributes(status: SUCCESS_STATUS)
+    update(status: SUCCESS_STATUS)
   end
 
   def mark_as_error(msg)
-    update_attributes(status: ERROR_STATUS, message: msg)
+    update(status: ERROR_STATUS, message: msg)
   end
 
   def mark_as_partial
-    update_attributes(partial: true)
+    update(partial: true)
   end
 
   def clean_synchronizations

--- a/lib/generators/connector/complex_entity_generator.rb
+++ b/lib/generators/connector/complex_entity_generator.rb
@@ -1,7 +1,7 @@
 module Connector
   module Generators
     class ComplexEntityGenerator < ::Rails::Generators::Base
-      source_root File.expand_path('../templates', __FILE__)
+      source_root File.expand_path('templates', __dir__)
 
       def copy_example_files
         copy_file 'complex_entity_example/contact_and_lead.rb', 'app/models/entities/example_contact_and_lead.rb'

--- a/lib/generators/connector/install_generator.rb
+++ b/lib/generators/connector/install_generator.rb
@@ -2,7 +2,7 @@ require 'fileutils'
 
 module Connector
   class InstallGenerator < ::Rails::Generators::Base
-    source_root File.expand_path('../templates', __FILE__)
+    source_root File.expand_path('templates', __dir__)
     desc 'Creating a Maestrano Connector application'
 
     def maestrano_generator

--- a/lib/generators/connector/templates/home_index.haml
+++ b/lib/generators/connector/templates/home_index.haml
@@ -64,9 +64,9 @@
                 - current_organization.displayable_synchronized_entities.each do |k, v|
                   .row.sync-entity
                     .col-md-1.link-step-action
-                      #{check_box("#{k}", "to_connec", {checked: (v[:can_push_to_connec] || v[:can_push_to_external]) && !current_organization.pull_disabled, onclick: "return !#{k}_to_external.checked;", disabled: current_organization.pull_disabled})}
+                      #{check_box("#{k}", "to_connec", {checked: (v[:can_push_to_connec] || v[:can_push_to_external]) && !current_organization.pull_disabled, onclick: "return !#{k}_to_external.checked;", disabled: current_organization.pull_disabled || !v[:can_push_to_connec]})}
                     .col-md-1.link-step-action
-                      #{check_box("#{k}", "to_external", {checked: v[:can_push_to_external] && !current_organization.push_disabled, onchange: "#{k}_to_connec.checked = #{!current_organization.pull_disabled};", disabled: current_organization.push_disabled})}
+                      #{check_box("#{k}", "to_external", {checked: v[:can_push_to_external] && !current_organization.push_disabled, onchange: "#{k}_to_connec.checked = #{!current_organization.pull_disabled};", disabled: current_organization.push_disabled || !v[:can_push_to_external]})}
                     %label.col-md-7{:for => "#{k}", style: 'padding-top: 5px;'}
                       .col-md-6
                         #{v[:external_name]}

--- a/lib/maestrano/connector/rails.rb
+++ b/lib/maestrano/connector/rails.rb
@@ -14,7 +14,6 @@ require 'attr_encrypted'
 require 'sidekiq'
 require 'sidekiq-cron'
 require 'sidekiq-unique-jobs'
-require 'sinatra'
 require 'slim'
 
 module Maestrano

--- a/maestrano-connector-rails.gemspec
+++ b/maestrano-connector-rails.gemspec
@@ -40,7 +40,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('sidekiq', '~> 4.2.9')
   s.add_runtime_dependency('sidekiq-cron')
   s.add_runtime_dependency('sidekiq-unique-jobs')
-  s.add_runtime_dependency('sinatra')
   s.add_runtime_dependency('slim')
 
   s.add_development_dependency('bundler')

--- a/template/files/spec_helper.rb
+++ b/template/files/spec_helper.rb
@@ -5,7 +5,7 @@ SimpleCov.start
 
 ENV['RAILS_ENV'] ||= 'test'
 
-require File.expand_path('../../config/environment', __FILE__)
+require File.expand_path('../config/environment', __dir__)
 require 'rspec/rails'
 require 'factory_girl_rails'
 require 'shoulda/matchers'


### PR DESCRIPTION
Updated handling of synchronized entities. If specific entities have push/pull disabled this will now be taken into account. It will also cause the checkboxes to be disabled in the `home#index` view.