### PR TITLE
Randomise cron job time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.3.0
+
+* Send data to Connec! even if the push/pull parameters are disabled (Transac! integration)
+* Randomise cron jobs time to avoid connectors crowding
+* Fix duplicated Sidekiq UI configuration and time based attack 
+
 ## 2.2.1
 
 * Fix a bug where the CreationMapper was used to map updates coming from external

--- a/spec/jobs/all_synchronizations_job_spec.rb
+++ b/spec/jobs/all_synchronizations_job_spec.rb
@@ -7,11 +7,6 @@ describe Maestrano::Connector::Rails::AllSynchronizationsJob do
 
   subject { Maestrano::Connector::Rails::AllSynchronizationsJob.perform_now() }
 
-  # before{
-  #   organization_not_active.update(encrypted_oauth_token: Maestrano::Connector::Rails::Organization.encrypt_oauth_token('123', key: 'This is a key that is 256 bits!!', iv: 'This iv is 12 bytes or longer'))
-  #   organization_to_process.update(encrypted_oauth_token: Maestrano::Connector::Rails::Organization.encrypt_oauth_token('123', key: 'This is a key that is 256 bits!!', iv: 'This iv is 12 bytes or longer'))
-  # }
-
   describe 'perform' do
     it 'does not calls sync entity' do
       expect(Maestrano::Connector::Rails::SynchronizationJob).to_not receive(:perform_later).with(organization_not_linked.id, anything)

--- a/template/files/routes.rb
+++ b/template/files/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
 
   # Sidekiq Admin
   require 'sidekiq/web'
+  require 'sidekiq/cron/web'
   Sidekiq::Web.use Rack::Auth::Basic do |username, password|
     username == ENV['SIDEKIQ_USERNAME'] && password == ENV['SIDEKIQ_PASSWORD']
   end

--- a/template/files/routes.rb
+++ b/template/files/routes.rb
@@ -20,7 +20,8 @@ Rails.application.routes.draw do
   require 'sidekiq/web'
   require 'sidekiq/cron/web'
   Sidekiq::Web.use Rack::Auth::Basic do |username, password|
-    username == ENV['SIDEKIQ_USERNAME'] && password == ENV['SIDEKIQ_PASSWORD']
+    Rack::Utils.secure_compare(::Digest::SHA256.hexdigest(username), ::Digest::SHA256.hexdigest(ENV['SIDEKIQ_USERNAME'])) &
+      Rack::Utils.secure_compare(::Digest::SHA256.hexdigest(password), ::Digest::SHA256.hexdigest(ENV['SIDEKIQ_PASSWORD']))
   end
   mount Sidekiq::Web => '/sidekiq'
 end

--- a/template/files/sidekiq.rb
+++ b/template/files/sidekiq.rb
@@ -2,5 +2,5 @@
 
 # Schedule cron jobs at a random minute to avoid crowding of all connectors
 minute = rand(60)
-Sidekiq::Cron::Job.create(name: 'all_syncrhonizations_job', cron: "#{minute} * * * *", class: 'Maestrano::Connector::Rails::AllSynchronizationsJob')
+Sidekiq::Cron::Job.create(name: 'all_synchronizations_job', cron: "#{minute} * * * *", class: 'Maestrano::Connector::Rails::AllSynchronizationsJob')
 Sidekiq::Cron::Job.create(name: 'update_configuration_job', cron: "#{minute} * * * *", class: 'Maestrano::Connector::Rails::UpdateConfigurationJob')

--- a/template/files/sidekiq.rb
+++ b/template/files/sidekiq.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 
-require 'sidekiq/web'
-
-Sidekiq::Cron::Job.create(name: 'AllSynchronizationsJob runs every hour', cron: '0 * * * *', class: 'Maestrano::Connector::Rails::AllSynchronizationsJob')
-Sidekiq::Cron::Job.create(name: 'UpdateConfigurationJob runs every hour', cron: '0 * * * *', class: 'Maestrano::Connector::Rails::UpdateConfigurationJob')
-
-# Sidekiq Admin
-Sidekiq::Web.use Rack::Auth::Basic do |username, password|
-  username == ENV['SIDEKIQ_USERNAME'] && password == ENV['SIDEKIQ_PASSWORD']
-end
+# Schedule cron jobs at a random minute to avoid crowding of all connectors
+minute = rand(60)
+Sidekiq::Cron::Job.create(name: 'all_syncrhonizations_job', cron: "#{minute} * * * *", class: 'Maestrano::Connector::Rails::AllSynchronizationsJob')
+Sidekiq::Cron::Job.create(name: 'update_configuration_job', cron: "#{minute} * * * *", class: 'Maestrano::Connector::Rails::UpdateConfigurationJob')


### PR DESCRIPTION
Synchronisation job runs at a random minute to avoid all connectors running at the same time.
Remove duplicate sidekiq UI configuration