### PR TITLE
Do not skip Connec! webhook on push_disabled (transac! compatibility)

### DIFF
--- a/app/controllers/maestrano/synchronizations_controller.rb
+++ b/app/controllers/maestrano/synchronizations_controller.rb
@@ -71,13 +71,12 @@ class Maestrano::SynchronizationsController < Maestrano::Rails::WebHookControlle
     end
 
     def organization_status(organization)
-      last_sync = organization.synchronizations.last
       if Maestrano::Connector::Rails::SynchronizationJob.find_running_job(organization.id)
         'RUNNING'
       elsif Maestrano::Connector::Rails::SynchronizationJob.find_job(organization.id)
         'ENQUEUED'
       else
-        last_sync&.status || 'DISABLED'
+        organization.synchronizations.last&.status || 'DISABLED'
       end
     end
 end

--- a/app/controllers/version_controller.rb
+++ b/app/controllers/version_controller.rb
@@ -5,7 +5,7 @@ class VersionController < ApplicationController
     commit = ENV['GIT_COMMIT_ID']
 
     respond_to do |format|
-      format.html { render text: "framework_version=#{framework_version}\nci_branch=#{branch}\nci_commit=#{commit}\nenv=#{Rails}\nnv, ruby_version=#{RUBY_VERSION}\nruby_engine=#{RUBY_ENGINE}\n" }
+      format.html { render text: "framework_version=#{framework_version}\nci_branch=#{branch}\nci_commit=#{commit}\nenv=#{Rails.env}\nruby_version=#{RUBY_VERSION}\nruby_engine=#{RUBY_ENGINE}\n" }
       format.json { render json: {framework_version: framework_version, ci_branch: branch, ci_commit: commit, env: Rails.env, ruby_version: RUBY_VERSION, ruby_engine: RUBY_ENGINE} }
     end
   end

--- a/app/models/maestrano/connector/rails/concerns/organization.rb
+++ b/app/models/maestrano/connector/rails/concerns/organization.rb
@@ -62,7 +62,7 @@ module Maestrano::Connector::Rails::Concerns::Organization
       entity_push_to_connec = clazz && clazz < Maestrano::Connector::Rails::Entity ? clazz.can_write_connec? : true
       entity_push_to_external = clazz && clazz < Maestrano::Connector::Rails::Entity ? clazz.can_write_external? : true
 
-      synchronized_entities[entity.to_sym] = {can_push_to_connec: !pull_disabled && entity_push_to_connec, can_push_to_external: !push_disabled && entity_push_to_external}
+      synchronized_entities[entity.to_sym] = {can_push_to_connec: entity_push_to_connec, can_push_to_external: entity_push_to_external}
     end
   end
 

--- a/lib/generators/connector/templates/home_index.haml
+++ b/lib/generators/connector/templates/home_index.haml
@@ -64,9 +64,9 @@
                 - current_organization.displayable_synchronized_entities.each do |k, v|
                   .row.sync-entity
                     .col-md-1.link-step-action
-                      #{check_box("#{k}", "to_connec", {checked: (v[:can_push_to_connec] || v[:can_push_to_external]) && !current_organization.pull_disabled, onclick: "return !#{k}_to_external.checked;", disabled: current_organization.pull_disabled || !v[:can_push_to_connec]})}
+                      #{check_box("#{k}", "to_connec", {checked: (v[:can_push_to_connec] || v[:can_push_to_external])})}
                     .col-md-1.link-step-action
-                      #{check_box("#{k}", "to_external", {checked: v[:can_push_to_external] && !current_organization.push_disabled, onchange: "#{k}_to_connec.checked = #{!current_organization.pull_disabled};", disabled: current_organization.push_disabled || !v[:can_push_to_external]})}
+                      #{check_box("#{k}", "to_external", {checked: v[:can_push_to_external], disabled: !v[:can_push_to_external]})}
                     %label.col-md-7{:for => "#{k}", style: 'padding-top: 5px;'}
                       .col-md-6
                         #{v[:external_name]}


### PR DESCRIPTION
The model `Organization` sets flags to skip data-sharing scenarios when push/pull are disabled, we need to skip this behaviour with Transac!