### PR TITLE
Update framework generators and template

### DIFF
--- a/app/controllers/maestrano/account/groups_controller.rb
+++ b/app/controllers/maestrano/account/groups_controller.rb
@@ -10,7 +10,7 @@ class Maestrano::Account::GroupsController < Maestrano::Rails::WebHookController
 
     unless organization
       Maestrano::Connector::Rails::ConnectorLogger.log('info', nil, 'Organization not found')
-      return render json: {success: true}, status: 204
+      return render json: {success: true}, status: :no_content
     end
 
     Maestrano::Connector::Rails::ConnectorLogger.log('info', organization, 'delete organization')

--- a/db/migrate/20170315032224_add_metadata_to_id_map.rb
+++ b/db/migrate/20170315032224_add_metadata_to_id_map.rb
@@ -1,5 +1,5 @@
 class AddMetadataToIdMap < ActiveRecord::Migration
   def change
-  	add_column :id_maps, :metadata, :text
+    add_column :id_maps, :metadata, :text
   end
 end

--- a/lib/generators/connector/install_generator.rb
+++ b/lib/generators/connector/install_generator.rb
@@ -6,7 +6,7 @@ module Connector
     desc 'Creating a Maestrano Connector application'
 
     def maestrano_generator
-      generate 'maestrano:initializer'
+      generate 'maestrano:install'
     end
 
     def include_helpers

--- a/lib/generators/connector/templates/home.js
+++ b/lib/generators/connector/templates/home.js
@@ -19,6 +19,10 @@ function closeModal(sender)
   $('#myModal').modal('hide');
 }
 
+$(function () {
+  $('[data-toggle="tooltip"]').tooltip()
+})
+
 $(document).ready(function(){
     $("#myModal").on('hidden.bs.modal', function (e) {
       if (!checkHistorical) {
@@ -28,8 +32,3 @@ $(document).ready(function(){
       checkHistorical = false
     });
 });
-
-
-$(function () {
-  $('[data-toggle="tooltip"]').tooltip()
-})

--- a/lib/generators/connector/templates/home_controller.rb
+++ b/lib/generators/connector/templates/home_controller.rb
@@ -5,10 +5,10 @@ class HomeController < ApplicationController
 
     # Update list of entities to synchronize
     current_organization.synchronized_entities.keys.each do |entity|
-      next unless params[entity.to_s]
       current_organization.synchronized_entities[entity][:can_push_to_connec] = params[entity.to_s]["to_connec"] == "1"
       current_organization.synchronized_entities[entity][:can_push_to_external] = params[entity.to_s]["to_external"] == "1"
     end
+
     full_sync = params['historical-data'].present? && !current_organization.historical_data
     opts = {full_sync: full_sync}
     current_organization.sync_enabled = current_organization.synchronized_entities.values.any? { |settings| settings.values.any? { |v| v } }
@@ -31,13 +31,13 @@ class HomeController < ApplicationController
 
   # Implement the redirection to the external application
   def redirect_to_external
-    redirect_to 'https://path/to/external/app'
+    redirect_to 'https://your_application.com'
   end
 
   private
 
-    def start_synchronization(opts)
-      Maestrano::Connector::Rails::SynchronizationJob.perform_later(current_organization.id, opts)
-      flash[:info] = 'Congrats, you\'re all set up! Your data are now being synced' if current_organization.sync_enabled_changed?
-    end
+  def start_synchronization(opts)
+    Maestrano::Connector::Rails::SynchronizationJob.perform_later(current_organization.id, opts)
+    flash[:info] = 'Congrats, you\'re all set up! Your data are now being synced' if current_organization.sync_enabled_changed?
+  end
 end

--- a/lib/generators/connector/templates/home_controller_spec.rb
+++ b/lib/generators/connector/templates/home_controller_spec.rb
@@ -114,6 +114,6 @@ describe HomeController, type: :controller do
       allow_any_instance_of(Maestrano::Connector::Rails::SessionHelper).to receive(:current_organization).and_return(organization)
     end
 
-    it {expect(subject).to redirect_to('https://somewhere.com')}
+    it {expect(subject).to redirect_to('https://your_application.com')}
   end
 end

--- a/lib/generators/connector/templates/home_index.haml
+++ b/lib/generators/connector/templates/home_index.haml
@@ -64,9 +64,9 @@
                 - current_organization.displayable_synchronized_entities.each do |k, v|
                   .row.sync-entity
                     .col-md-1.link-step-action
-                      #{check_box("#{k}", "to_connec", {checked: (v[:can_push_to_connec] || v[:can_push_to_external])})}
+                      #{check_box("#{k}", "to_connec", {checked: (v[:can_push_to_connec] || v[:can_push_to_external]) && !current_organization.pull_disabled, onclick: "return !#{k}_to_external.checked;", disabled: current_organization.pull_disabled})}
                     .col-md-1.link-step-action
-                      #{check_box("#{k}", "to_external", {checked: v[:can_push_to_external], disabled: !v[:can_push_to_external]})}
+                      #{check_box("#{k}", "to_external", {checked: v[:can_push_to_external] && !current_organization.push_disabled, onchange: "#{k}_to_connec.checked = #{!current_organization.pull_disabled};", disabled: current_organization.push_disabled})}
                     %label.col-md-7{:for => "#{k}", style: 'padding-top: 5px;'}
                       .col-md-6
                         #{v[:external_name]}
@@ -79,7 +79,7 @@
 
             .spacer2
             .row
-              %h Chose whether to synchronize your historical data:
+              %h Choose whether to synchronize your historical data:
             .spacer1
             .row
               .col-md-4.col-md-offset-1
@@ -127,3 +127,7 @@
         .row
           .col-md-4.col-md-offset-4.text-center
             = link_to 'Go to ApplicationName', home_redirect_to_external_path, class: 'btn btn-lg btn-primary'
+      -else
+        .row
+          .col-md-4.col-md-offset-4.center
+            = link_to 'Link your Maestrano account', Maestrano::Connector::Rails::Engine.routes.url_helpers.default_maestrano_auth_saml_index_path(tenant: :default), class: 'btn btn-warning'

--- a/template/files/Gemfile.tt
+++ b/template/files/Gemfile.tt
@@ -5,24 +5,35 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :jruby]
 
 gem 'puma', require: false
 
-gem 'maestrano-connector-rails', '>= 2.0.2.pre.RC6'
+gem 'maestrano-connector-rails', '~> 2.3.1'
 
+gem 'jquery-rails'
 gem 'jsonapi-resources'
 gem 'jsonapi-resources-matchers', require: false
 gem 'pundit'
 gem 'pundit-matchers'
 gem 'pundit-resources'
+gem 'turbolinks', '~> 2.5'
+gem 'uglifier'
+gem 'spring'
 
 group :production, :uat do
   gem 'activerecord-jdbcmysql-adapter', platforms: :jruby
-  gem 'mysql2', platforms: :ruby
+  # Lock mysql2 to an old version for now as there is a bug in Rails 4.1.x and 4.2.x
+  # The bug prevents activerecord from using the most recent version of mysql2.
+  # See: https://stackoverflow.com/questions/32457657/rails-4-gemloaderror-specified-mysql2-for-database-adapter-but-the-gem-i
+  gem 'mysql2', '~> 0.3.18', platforms: :ruby
   gem 'rails_12factor'
 end
 
 group :test, :development do
   gem 'activerecord-jdbcsqlite3-adapter', platforms: :jruby
+  gem 'brakeman', require: false
+  gem 'bundler-audit', require: false
+  gem 'pry-byebug', platforms: :ruby
+  gem 'rubocop', require: false
+  gem 'rubocop-rspec', require: false
   gem 'sqlite3', platforms: :ruby
-  gem 'rubocop'
 end
 
 group :test do
@@ -31,4 +42,6 @@ group :test do
   gem 'factory_girl_rails'
   gem 'shoulda-matchers'
   gem 'timecop'
+  gem 'webmock'
+  gem 'rspec_junit_formatter'
 end

--- a/template/files/Procfile
+++ b/template/files/Procfile
@@ -1,2 +1,2 @@
-web: bin/puma -t 5:5 -p $PORT -e $RACK_ENV
+web: bin/puma -t ${RAILS_MAX_THREADS:-5}:${RAILS_MAX_THREADS:-5} -p $PORT -e $RACK_ENV
 worker: bin/sidekiq

--- a/template/files/spec_helper.rb
+++ b/template/files/spec_helper.rb
@@ -10,6 +10,7 @@ require 'rspec/rails'
 require 'factory_girl_rails'
 require 'shoulda/matchers'
 require 'maestrano_connector_rails/factories.rb'
+require 'webmock/rspec'
 
 Rails.backtrace_cleaner.remove_silencers!
 
@@ -22,4 +23,9 @@ RSpec.configure do |config|
   config.infer_base_class_for_anonymous_controllers = false
   config.order = 'random'
   config.include FactoryGirl::Syntax::Methods
+  config.before(:each) do
+    stub_request(:get, %r{https://maestrano.com/api/v1/account/groups/\w+})
+      .with(headers: {'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Basic Og==', 'User-Agent' => 'Ruby'})
+      .to_return(status: 200, body: '{}', headers: {})
+  end
 end

--- a/template/maestrano_connector_template.rb
+++ b/template/maestrano_connector_template.rb
@@ -42,6 +42,7 @@ def apply_template!
     copy_file 'files/sidekiq.rb', 'config/initializers/sidekiq.rb'
 
     # Settings
+    run 'spring stop'
     run 'bundle exec rails g config:install'
     remove_dir 'config/settings'
     remove_file 'config/settings.yml'
@@ -66,14 +67,16 @@ def apply_template!
     run 'SKIP_CONFIGURATION=true bundle exec rails g connector:install'
     run 'bundle exec figaro install'
     run 'bundle exec rake railties:install:migrations'
-    run 'SKIP_CONFIGURATION=true bundle exec rake db:migrate'
 
-    run 'bundler binstubs puma --force'
-    run 'bundler binstubs sidekiq --force'
-    run 'bundler binstubs rake --force'
+    run 'bundle binstubs bundler --force'
+    run 'bundle binstubs puma --force'
+    run 'bundle binstubs sidekiq --force'
+    run 'bundle binstubs rake --force'
 
     remove_file 'config/initializers/maestrano.rb'
     copy_file 'files/maestrano.rb', 'config/initializers/maestrano.rb'
+
+    run 'SKIP_CONFIGURATION=true bundle exec rake db:migrate'
 
     # Init repo and commit
     git :init


### PR DESCRIPTION
@cesar-tonnoir @BrunoChauvet @MarcoBgn The templates/generators had some issues, mostly related to wrong commands being run (Ex. bundler binstubs... vs. bundle binstubs), as well as commands being run in the wrong order.

This will fix those issues as well as update the framework to 2.3.1 so we will no longer have to migrate to the new version each time a connector is created.

The only issue that will persist is in `install_generator.rb`. `generate 'maestrano:initializer'` is being called when it should be `generate 'maestrano:install'`. This pr will fix that but the generator will be overwritten by the gem, so that problem will persist until a new version is tagged.

Once a new version is tagged, the gem in `Gemfile.tt` just needs the version updated to the new tag and then the template will work without any errors.