### PR TITLE
Rubofix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,6 @@
-source 'http://rubygems.org'
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
 
 gemspec
 

--- a/app/controllers/maestrano/connec_controller.rb
+++ b/app/controllers/maestrano/connec_controller.rb
@@ -9,6 +9,7 @@ class Maestrano::ConnecController < Maestrano::Rails::WebHookController
           begin
             organization = find_valid_organization(entity[:group_id], params[:tenant], entity_class_hash)
             next if organization.blank?
+
             Maestrano::Connector::Rails::ConnectorLogger.log('info', organization, "Processing entity from Connec! webhook, entity_name=\"#{entity_name}\", data=\"#{entity}\"")
 
             connec_client = Maestrano::Connector::Rails::ConnecHelper.get_client(organization)

--- a/app/jobs/maestrano/connector/rails/concerns/synchronization_job.rb
+++ b/app/jobs/maestrano/connector/rails/concerns/synchronization_job.rb
@@ -75,6 +75,7 @@ module Maestrano::Connector::Rails::Concerns::SynchronizationJob
         Maestrano::Connector::Rails::ConnectorLogger.log('info', organization, 'First synchronization ever. Doing two half syncs to allow smart merging to work its magic.')
         organization.synchronized_entities.each do |entity, settings|
           next unless settings[:can_push_to_connec] || settings[:can_push_to_external]
+
           Maestrano::Connector::Rails::ConnectorLogger.log('info', organization, "First synchronization ever. Doing half sync from external for #{entity}.")
           first_sync_entity(entity.to_s, organization, connec_client, external_client, last_synchronization_date, opts, true)
           Maestrano::Connector::Rails::ConnectorLogger.log('info', organization, "First synchronization ever. Doing half sync from Connec! for #{entity}.")
@@ -90,6 +91,7 @@ module Maestrano::Connector::Rails::Concerns::SynchronizationJob
       else
         organization.synchronized_entities.each do |entity, settings|
           next unless settings[:can_push_to_connec] || settings[:can_push_to_external]
+
           sync_entity(entity.to_s, organization, connec_client, external_client, last_synchronization_date, opts)
         end
       end
@@ -136,6 +138,7 @@ module Maestrano::Connector::Rails::Concerns::SynchronizationJob
       # We're comparing the first record to check that it is different
       first_record = Digest::MD5.hexdigest(perform_hash[:first].to_s)
       break if last_first_record && first_record == last_first_record
+
       last_first_record = first_record
 
       skip += limit

--- a/app/jobs/maestrano/connector/rails/concerns/synchronization_job.rb
+++ b/app/jobs/maestrano/connector/rails/concerns/synchronization_job.rb
@@ -14,10 +14,10 @@ module Maestrano::Connector::Rails::Concerns::SynchronizationJob
       queue = Sidekiq::Queue.new(:default)
       queue.find do |job|
         job_organization_id = begin
-          job.item['args'][0]['arguments'].first
-        rescue
-          false
-        end
+                                job.item['args'][0]['arguments'].first
+                              rescue
+                                false
+                              end
         organization_id == job_organization_id
       end
     end
@@ -25,10 +25,10 @@ module Maestrano::Connector::Rails::Concerns::SynchronizationJob
     def find_running_job(organization_id)
       Sidekiq::Workers.new.find do |_, _, work|
         job_organization_id = begin
-          work['payload']['args'][0]['arguments'].first
-        rescue
-          false
-        end
+                                work['payload']['args'][0]['arguments'].first
+                              rescue
+                                false
+                              end
         work['queue'] == 'default' && organization_id == job_organization_id
       end
     rescue

--- a/app/jobs/maestrano/connector/rails/concerns/update_configuration_job.rb
+++ b/app/jobs/maestrano/connector/rails/concerns/update_configuration_job.rb
@@ -8,6 +8,7 @@ module Maestrano::Connector::Rails::Concerns::UpdateConfigurationJob
 
   def perform
     return if ENV['SKIP_CONFIGURATION']
+
     Maestrano.reset!
     Maestrano.auto_configure
   rescue StandardError => e

--- a/app/models/maestrano/connector/rails/concerns/complex_entity.rb
+++ b/app/models/maestrano/connector/rails/concerns/complex_entity.rb
@@ -24,6 +24,7 @@ module Maestrano::Connector::Rails::Concerns::ComplexEntity
 
     def formatted_entities_names(names)
       return names.with_indifferent_access if names.is_a?(Hash)
+
       names.index_by { |name| name }.with_indifferent_access
     end
 
@@ -44,6 +45,7 @@ module Maestrano::Connector::Rails::Concerns::ComplexEntity
     def public_name(formatted_names)
       names = formatted_names.keys.map(&:pluralize)
       return names.first.humanize if names.size == 1
+
       (names[0..-2].join(', ') + " and #{names.last}").humanize
     end
   end

--- a/app/models/maestrano/connector/rails/concerns/connec_helper.rb
+++ b/app/models/maestrano/connector/rails/concerns/connec_helper.rb
@@ -119,6 +119,7 @@ module Maestrano::Connector::Rails::Concerns::ConnecHelper
       # Unfold the id
       if array_of_refs.empty? && field
         return entity.delete(ref) if field.is_a?(String) # ~retro-compatibility to ease transition aroud Connec! idmaps rework. Should be removed eventually.
+
         id_hash = field.find { |id| id[:provider] == organization.oauth_provider && id[:realm] == organization.oauth_uid }
         if id_hash
           entity[ref] = id_hash['id']
@@ -134,6 +135,7 @@ module Maestrano::Connector::Rails::Concerns::ConnecHelper
       # Follow embedment path
       else
         return true if field.blank?
+
         case field
         when Array
           bool = true
@@ -151,6 +153,7 @@ module Maestrano::Connector::Rails::Concerns::ConnecHelper
     # References can either be an array (only record references), or a hash
     def format_references(references)
       return {record_references: references, id_references: []} if references.is_a?(Array)
+
       references[:record_references] ||= []
       references[:id_references] ||= []
       references
@@ -173,6 +176,7 @@ module Maestrano::Connector::Rails::Concerns::ConnecHelper
     # Recursive method for filtering connec entities
     def filter_connec_entity_for_id_refs_helper(entity_hash, tree)
       return if tree.empty?
+
       entity_hash.slice!(*tree.keys)
 
       tree.each do |key, children|

--- a/app/models/maestrano/connector/rails/concerns/entity.rb
+++ b/app/models/maestrano/connector/rails/concerns/entity.rb
@@ -273,6 +273,7 @@ module Maestrano::Connector::Rails::Concerns::Entity
       mapped_external_entities_with_idmaps.each do |mapped_external_entity_with_idmap|
         id_map = mapped_external_entity_with_idmap[:idmap]
         next unless id_map&.metadata&.dig(:ignore_currency_update)
+
         self.class.currency_check_fields.each do |field|
           mapped_external_entity_with_idmap[:entity].delete(field)
         end
@@ -302,6 +303,7 @@ module Maestrano::Connector::Rails::Concerns::Entity
   # Wrapper to process options and limitations
   def get_external_entities_wrapper(last_synchronization_date = nil, entity_name = self.class.external_entity_name)
     return [] if @opts[:__skip_external] || !self.class.can_read_external?
+
     get_external_entities(entity_name, last_synchronization_date)
   end
 
@@ -367,6 +369,7 @@ module Maestrano::Connector::Rails::Concerns::Entity
       # Update
       else
         return nil unless self.class.can_update_external?
+
         external_hash = update_external_entity(mapped_connec_entity, idmap.external_id, external_entity_name)
 
         completed_hash = map_and_complete_hash_with_connec_ids(external_hash, external_entity_name, id_refs_only_connec_entity)
@@ -479,6 +482,7 @@ module Maestrano::Connector::Rails::Concerns::Entity
         response = @connec_client.batch(batch_request)
         Maestrano::Connector::Rails::ConnectorLogger.log('debug', @organization, "Received batch response from Connec! for #{self.class.normalize_connec_entity_name(connec_entity_name)}: #{response}")
         raise "No data received from Connec! when trying to send batch request #{log_info} for #{self.class.connec_entity_name.pluralize}" unless response && response.body.present?
+
         response = JSON.parse(response.body)
 
         # Parse batch response

--- a/app/models/maestrano/connector/rails/concerns/organization.rb
+++ b/app/models/maestrano/connector/rails/concerns/organization.rb
@@ -114,6 +114,7 @@ module Maestrano::Connector::Rails::Concerns::Organization
   def enable_historical_data(enabled)
     # Historical data sharing cannot be unset
     return if historical_data
+
     if enabled
       self.date_filtering_limit = nil
       self.historical_data = true

--- a/app/models/maestrano/connector/rails/concerns/sub_entity_base.rb
+++ b/app/models/maestrano/connector/rails/concerns/sub_entity_base.rb
@@ -12,11 +12,13 @@ module Maestrano::Connector::Rails::Concerns::SubEntityBase
 
     def external_entity_name
       return entity_name if external?
+
       raise 'Forbidden call: cannot call external_entity_name for a connec entity'
     end
 
     def connec_entity_name
       return entity_name unless external?
+
       raise 'Forbidden call: cannot call connec_entity_name for an external entity'
     end
 

--- a/app/policies/maestrano/connector/rails/application_policy.rb
+++ b/app/policies/maestrano/connector/rails/application_policy.rb
@@ -16,6 +16,7 @@ class Maestrano::Connector::Rails::ApplicationPolicy
   def initialize(user, record)
     # Closed system: must be logged in to do anything
     raise Pundit::NotAuthorizedError, 'must be logged in' unless user
+
     @user = user
     @record = record
   end

--- a/app/resources/maestrano/api/base_resource.rb
+++ b/app/resources/maestrano/api/base_resource.rb
@@ -16,6 +16,7 @@ module Maestrano
       def self.all_filters
         # Skipping if there is no tables as calling columns_hash in attribute_type is causing issue
         return unless tables_exists?
+
         _attributes.keys.each do |attribute|
           type = attribute_type(attribute)
           if type == :boolean
@@ -34,6 +35,7 @@ module Maestrano
           # iterating through all the api operator and adding them as custom filter
           # name.gt, name.like etc...
           next unless _model_class
+
           field = "#{_model_class.table_name}.#{key}"
 
           API_SQL_OPERATOR_MAPPING.each do |api_operator, sql_operator|

--- a/app/resources/maestrano/api/user_resource.rb
+++ b/app/resources/maestrano/api/user_resource.rb
@@ -15,6 +15,7 @@ module Maestrano
         @model.tenant = context[:client]
         super
         return unless org_uid == context.dig(:params, :org_uid)
+
         org = Maestrano::Connector::Rails::Organization.find_by(org_uid: org_uid)
         org.add_member(@model) unless !org || org.member?(@model)
       end


### PR DESCRIPTION
The `Layout/EmptyLineAfterGuardClause` might be a bit overkill for some short methods like:
```ruby
    def external_entity_name
      return entity_name if external?

      raise 'Forbidden call: cannot call external_entity_name for a connec entity'
    end

    def connec_entity_name
      return entity_name unless external?

      raise 'Forbidden call: cannot call connec_entity_name for an external entity'
    end
```