### PR TITLE
 [APPINT-1205] Fix cron jobs & cleanup template

### DIFF
--- a/app/jobs/maestrano/connector/rails/all_synchronizations_job.rb
+++ b/app/jobs/maestrano/connector/rails/all_synchronizations_job.rb
@@ -4,15 +4,12 @@ module Maestrano::Connector::Rails
 
     # Trigger synchronization of all active organizations
     def perform(name = nil, count = nil)
-      active_organizations = Maestrano::Connector::Rails::Organization
-                             .where.not(oauth_provider: nil, encrypted_oauth_token: nil)
-                             .select { |o| [true, 1].include?(o.sync_enabled) }
-
-      return true if active_organizations.count.zero?
-
-      time_span_seconds = (3600 / active_organizations.count).to_i
-      active_organizations.each_with_index do |organization, i|
-        Maestrano::Connector::Rails::SynchronizationJob.set(wait: time_span_seconds * i).perform_later(organization.id, {})
+      Maestrano::Connector::Rails::Organization
+        .where.not(oauth_provider: nil, encrypted_oauth_token: nil)
+        .where(sync_enabled: true)
+        .select(:id)
+        .find_each do |organization|
+        Maestrano::Connector::Rails::SynchronizationJob.set(wait: rand(3600)).perform_later(organization.id, {})
       end
     end
   end

--- a/lib/generators/connector/install_generator.rb
+++ b/lib/generators/connector/install_generator.rb
@@ -71,5 +71,10 @@ module Connector
     def copy_oauth_controller
       copy_file 'oauth_controller.rb', 'app/controllers/oauth_controller.rb'
     end
+
+    def cleanup
+      # The connector framework already provide a working implementation of this controller
+      remove_file 'app/controllers/maestrano/account/groups_controller.rb'
+    end
   end
 end

--- a/template/files/sidekiq.rb
+++ b/template/files/sidekiq.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-# Ensure all jobs are removed before creating them
-Sidekiq::Cron::Job.destroy_all!
-
-# Schedule cron jobs at a random minute to avoid crowding of all connectors
-minute = rand(60)
-Sidekiq::Cron::Job.create(name: 'all_synchronizations_job', cron: "#{minute} * * * *", class: 'Maestrano::Connector::Rails::AllSynchronizationsJob')
-Sidekiq::Cron::Job.create(name: 'update_configuration_job', cron: "#{minute} * * * *", class: 'Maestrano::Connector::Rails::UpdateConfigurationJob')
+# Sidekiq Cron configuration
+schedule_file = 'config/sidekiq_cron.yml'
+Sidekiq::Cron::Job.load_from_hash! YAML.load_file(schedule_file) if File.exist?(schedule_file)

--- a/template/files/sidekiq_cron.yml.tt
+++ b/template/files/sidekiq_cron.yml.tt
@@ -1,0 +1,7 @@
+update_configuration_job:
+  cron: "<%= sidekiq_cron_minute %> * * * *"
+  class: 'Maestrano::Connector::Rails::UpdateConfigurationJob'
+
+all_synchronizations_job:
+  cron: "<%= (sidekiq_cron_minute + 1) % 60 %> * * * *"
+  class: 'Maestrano::Connector::Rails::AllSynchronizationsJob'

--- a/template/maestrano_connector_template.rb
+++ b/template/maestrano_connector_template.rb
@@ -13,8 +13,7 @@ def apply_template!
   #
   template 'files/Gemfile.tt', 'Gemfile', force: true
 
-  remove_file '.gitignore'
-  copy_file 'files/gitignore', '.gitignore'
+  copy_file 'files/gitignore', '.gitignore', force: true
   copy_file 'files/rubocop.yml', '.rubocop.yml'
 
   #
@@ -25,15 +24,13 @@ def apply_template!
     remove_dir 'test'
     remove_file 'app/views/layouts/application.html.erb'
     remove_file 'app/assets/stylesheets/application.css'
-    remove_file 'config/routes.rb'
     copy_file 'files/spec_helper.rb', 'spec/spec_helper.rb'
-    copy_file 'files/routes.rb', 'config/routes.rb'
+    copy_file 'files/routes.rb', 'config/routes.rb', force: true
 
     # Procfile and uat
     copy_file 'files/Procfile', 'Procfile'
     run 'cp config/environments/production.rb config/environments/uat.rb'
-    remove_file 'config/database.yml'
-    copy_file 'files/database.yml', 'config/database.yml'
+    copy_file 'files/database.yml', 'config/database.yml', force: true
     run 'echo \'uat:
     secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>\' >> config/secrets.yml'
 
@@ -44,14 +41,13 @@ def apply_template!
 
     # Settings
     run 'spring stop'
-    run 'bundle exec rails g config:install'
+    generate 'config:install'
     remove_dir 'config/settings'
-    remove_file 'config/settings.yml'
     run 'mkdir config/settings'
     %w(development production test uat).each do |file|
       copy_file "settings/#{file}.yml", "config/settings/#{file}.yml", force: true
     end
-    copy_file 'settings/settings.yml', 'config/settings.yml'
+    copy_file 'settings/settings.yml', 'config/settings.yml', force: true
 
     copy_file 'files/application-sample.yml', 'config/application-sample.yml'
 
@@ -65,9 +61,9 @@ def apply_template!
       RUBY
     end
 
-    run 'SKIP_CONFIGURATION=true bundle exec rails g connector:install'
+    generate 'connector:install SKIP_CONFIGURATION=true'
     run 'bundle exec figaro install'
-    run 'bundle exec rake railties:install:migrations'
+    rake 'railties:install:migrations'
 
     run 'bundle binstubs bundler --force'
     run 'bundle binstubs puma --force'
@@ -77,7 +73,7 @@ def apply_template!
     remove_file 'config/initializers/maestrano.rb'
     copy_file 'files/maestrano.rb', 'config/initializers/maestrano.rb'
 
-    run 'SKIP_CONFIGURATION=true bundle exec rake db:migrate'
+    rake 'db:migrate SKIP_CONFIGURATION=true'
 
     # Init repo and commit
     git :init

--- a/template/maestrano_connector_template.rb
+++ b/template/maestrano_connector_template.rb
@@ -40,6 +40,7 @@ def apply_template!
     # Sidekiq
     copy_file 'files/sidekiq.yml', 'config/sidekiq.yml'
     copy_file 'files/sidekiq.rb', 'config/initializers/sidekiq.rb'
+    template 'files/sidekiq_cron.yml.tt', 'config/sidekiq_cron.yml'
 
     # Settings
     run 'spring stop'
@@ -143,6 +144,11 @@ def ensure_valid_options
       fail Rails::Generators::Error, "Unsupported option: #{key}=#{actual}"
     end
   end
+end
+
+# Schedule cron jobs at a random minute to avoid crowding of all connectors
+def sidekiq_cron_minute
+  @sidekiq_cron_minute ||= rand(60)
 end
 
 apply_template!


### PR DESCRIPTION
## Fix cron jobs
The previous implementation (#169, #172, #173) was randomizing connector start time at every initialization by clearing the cron and recreating it.
This causes issues when debugging and trying to pause a job as the cron config is reset anytime Rails is initialized (rake, console, ...)

## Fix jobs spreading #173 
Previous code would clump everything as soon as > 3600 organizations.
Relying on the law of large numbers to spread evenly as we scale.
This allows us to do more efficient DB query as well.

## Fix account deletion controller
The connector framework provides a working implementation so we can delete the generated file from maestrano-rails. If not changed, the generated controller triggers 500.

## Cleanup rails template
Leverage the built in methods to simplify the template