### PR TITLE
[APPINT-1323] Retry call to Connec!

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,8 @@ Rails/ApplicationRecord:
   Enabled: false
 
 AllCops:
+  DisplayCopNames: true
+  DisplayStyleGuide: true
   TargetRubyVersion: 2.3
   Exclude:
     - 'maestrano-connector-rails.gemspec'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -14,7 +14,7 @@ Lint/AssignmentInCondition:
 
 # Offense count: 28
 Metrics/AbcSize:
-  Max: 69
+  Max: 70
 
 # Offense count: 1
 # Configuration parameters: CountComments.

--- a/app/models/maestrano/connector/rails/concerns/entity.rb
+++ b/app/models/maestrano/connector/rails/concerns/entity.rb
@@ -465,7 +465,7 @@ module Maestrano::Connector::Rails::Concerns::Entity
     # proc is a lambda to create a batch_op from an element of the array
     # Perform batch calls on Connec API and parse the response
     def batch_calls(array_with_idmap, proc, connec_entity_name, id_update_only = false)
-      request_per_call = @opts[:request_per_batch_call] || 100
+      request_per_call = @opts[:request_per_batch_call] || 50
       start = 0
       while start < array_with_idmap.size
         # Prepare batch request

--- a/app/models/maestrano/connector/rails/concerns/entity.rb
+++ b/app/models/maestrano/connector/rails/concerns/entity.rb
@@ -479,7 +479,7 @@ module Maestrano::Connector::Rails::Concerns::Entity
         # Batch call
         log_info = id_update_only ? 'with only ids' : ''
         Maestrano::Connector::Rails::ConnectorLogger.log('info', @organization, "Sending batch request to Connec! #{log_info} for #{self.class.normalize_connec_entity_name(connec_entity_name)}. Batch_request_size: #{batch_request[:ops].size}. Call_number: #{(start / request_per_call) + 1}")
-        response = @connec_client.batch(batch_request)
+        response = Retriable.with_context(:connec) { @connec_client.batch(batch_request) }
         Maestrano::Connector::Rails::ConnectorLogger.log('debug', @organization, "Received batch response from Connec! for #{self.class.normalize_connec_entity_name(connec_entity_name)}: #{response}")
         raise "No data received from Connec! when trying to send batch request #{log_info} for #{self.class.connec_entity_name.pluralize}" unless response && response.body.present?
 
@@ -505,7 +505,7 @@ module Maestrano::Connector::Rails::Concerns::Entity
 
     def fetch_connec(uri)
       Maestrano::Connector::Rails::ConnectorLogger.log('debug', @organization, "Fetching data from connec entity=#{self.class.connec_entity_name}, url=#{uri}")
-      response = @connec_client.get(uri)
+      response = Retriable.with_context(:connec) { @connec_client.get(uri) }
 
       raise "No data received from Connec! when trying to fetch #{self.class.normalized_connec_entity_name}" unless response && response.body.present?
 

--- a/config/initializers/retriable.rb
+++ b/config/initializers/retriable.rb
@@ -3,6 +3,8 @@
 CONNEC_RETRIABLE_ERRORS = [Net::OpenTimeout, Net::ReadTimeout].freeze
 
 Retriable.configure do |c|
+  c.tries = 3
+
   c.contexts[:connec] = {
     on: CONNEC_RETRIABLE_ERRORS,
     on_retry: proc do |exception, try, elapsed_time, next_interval|

--- a/config/initializers/retriable.rb
+++ b/config/initializers/retriable.rb
@@ -1,6 +1,10 @@
+# frozen_string_literal: true
+
+CONNEC_RETRIABLE_ERRORS = [Net::OpenTimeout, Net::ReadTimeout].freeze
+
 Retriable.configure do |c|
   c.contexts[:connec] = {
-    on: [Net::OpenTimeout, Net::ReadTimeout, Net::HTTPGatewayTimeOut],
+    on: CONNEC_RETRIABLE_ERRORS,
     on_retry: proc do |exception, try, elapsed_time, next_interval|
       Rails.logger.info "Connec! error - #{exception.class}: '#{exception.message}' - #{try} tries in #{elapsed_time} seconds and #{next_interval} seconds until the next try."
     end

--- a/config/initializers/retriable.rb
+++ b/config/initializers/retriable.rb
@@ -1,0 +1,8 @@
+Retriable.configure do |c|
+  c.contexts[:connec] = {
+    on: [Net::OpenTimeout, Net::ReadTimeout, Net::HTTPGatewayTimeOut],
+    on_retry: proc do |exception, try, elapsed_time, next_interval|
+      Rails.logger.info "Connec! error - #{exception.class}: '#{exception.message}' - #{try} tries in #{elapsed_time} seconds and #{next_interval} seconds until the next try."
+    end
+  }
+end

--- a/lib/maestrano/connector/rails.rb
+++ b/lib/maestrano/connector/rails.rb
@@ -1,4 +1,5 @@
 require 'maestrano-rails'
+require 'retriable'
 
 require 'haml-rails'
 require 'bootstrap-sass'

--- a/maestrano-connector-rails.gemspec
+++ b/maestrano-connector-rails.gemspec
@@ -37,6 +37,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('hash_mapper', '>= 0.2.2')
   s.add_runtime_dependency('pundit')
   s.add_runtime_dependency('pundit-resources')
+  s.add_runtime_dependency('retriable', '~> 3.1.2')
   s.add_runtime_dependency('sidekiq', '~> 4.2.9')
   s.add_runtime_dependency('sidekiq-cron')
   s.add_runtime_dependency('sidekiq-unique-jobs')

--- a/spec/models/entity_spec.rb
+++ b/spec/models/entity_spec.rb
@@ -342,6 +342,15 @@ describe Maestrano::Connector::Rails::Entity do
         end
 
         describe 'failures' do
+          context 'timeout error' do
+            before { allow(connec_client).to receive(:get).and_raise(Net::OpenTimeout) }
+
+            it 'retries and raise the error' do
+              expect {subject.get_connec_entities(nil)}.to raise_error(Net::OpenTimeout)
+              expect(connec_client).to have_received(:get).exactly(3).times
+            end
+          end
+
           context 'when no response' do
             before do
               allow(connec_client).to receive(:get).and_return(ActionDispatch::Response.new(200, {}, nil, {}))
@@ -546,6 +555,15 @@ describe Maestrano::Connector::Rails::Entity do
               subject.push_entities_to_connec_to(entities_with_idmaps, '')
               idmap2.reload
               expect(idmap2.message).to eq err_msg.truncate(255)
+            end
+          end
+
+          context 'timeout error' do
+            before { allow(connec_client).to receive(:batch).and_raise(Net::OpenTimeout) }
+
+            it 'retries and raise the error' do
+              expect {subject.push_entities_to_connec_to(entities_with_idmaps, '')}.to raise_error(Net::OpenTimeout)
+              expect(connec_client).to have_received(:batch).exactly(3).times
             end
           end
         end

--- a/spec/models/entity_spec.rb
+++ b/spec/models/entity_spec.rb
@@ -342,12 +342,14 @@ describe Maestrano::Connector::Rails::Entity do
         end
 
         describe 'failures' do
-          context 'timeout error' do
-            before { allow(connec_client).to receive(:get).and_raise(Net::OpenTimeout) }
+          CONNEC_RETRIABLE_ERRORS.each do |error|
+            context "#{error}" do
+              before { allow(connec_client).to receive(:get).and_raise(error) }
 
-            it 'retries and raise the error' do
-              expect {subject.get_connec_entities(nil)}.to raise_error(Net::OpenTimeout)
-              expect(connec_client).to have_received(:get).exactly(3).times
+              it 'retries and raise the error' do
+                expect {subject.get_connec_entities(nil)}.to raise_error(error)
+                expect(connec_client).to have_received(:get).exactly(3).times
+              end
             end
           end
 

--- a/spec/models/entity_spec.rb
+++ b/spec/models/entity_spec.rb
@@ -497,9 +497,9 @@ describe Maestrano::Connector::Rails::Entity do
             let(:entities) { [] }
             let(:results) { [] }
 
-            context 'when 100 entities' do
+            context 'when 50 entities' do
               before do
-                100.times do
+                50.times do
                   entities << entity_with_idmap1
                   results << result200
                 end
@@ -512,9 +512,9 @@ describe Maestrano::Connector::Rails::Entity do
               end
             end
 
-            context 'when more than 100 entities' do
+            context 'when more than 50 entities' do
               before do
-                100.times do
+                50.times do
                   entities << entity_with_idmap1
                   results << result200
                 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -40,3 +40,10 @@ RSpec.configure do |config|
     Rails.cache.clear
   end
 end
+
+# Disable exponential backoff and wait in testing
+Retriable.configure do |c|
+  c.multiplier    = 1.0
+  c.rand_factor   = 0.0
+  c.base_interval = 0
+end


### PR DESCRIPTION
With default batch size of 100, the call may timeout if Connec! is under load.
This PR add retry with randomized exponential backoff on Connec! calls.
I've also lowered the default batch size to 50 to limit this issue.

I'll open another PR to address pagination and configurable batch size (APPINT-1322)

See maestrano/marlin-banking-adapter#22 for context