### PR TITLE
[MARLIN-496] fetch Organization using oauth_keys instead of oauth_token

### DIFF
--- a/app/jobs/maestrano/connector/rails/all_synchronizations_job.rb
+++ b/app/jobs/maestrano/connector/rails/all_synchronizations_job.rb
@@ -5,7 +5,7 @@ module Maestrano::Connector::Rails
     # Trigger synchronization of all active organizations
     def perform(name = nil, count = nil)
       Maestrano::Connector::Rails::Organization
-        .where.not(oauth_provider: nil, encrypted_oauth_token: nil)
+        .where.not(oauth_provider: nil, encrypted_oauth_keys: nil)
         .where(sync_enabled: true)
         .select(:id)
         .find_each do |organization|

--- a/app/models/maestrano/connector/rails/concerns/organization.rb
+++ b/app/models/maestrano/connector/rails/concerns/organization.rb
@@ -19,6 +19,7 @@ module Maestrano::Connector::Rails::Concerns::Organization
     attr_encrypted_options[:mode] = :per_attribute_iv_and_salt
     attr_encrypted :oauth_token, key: ::Settings.encryption_key1
     attr_encrypted :refresh_token, key: ::Settings.encryption_key2
+    attr_encrypted :oauth_keys, key: ::Settings.encryption_key2
 
     #===================================
     # Associations

--- a/db/migrate/20181120031753_add_full_o_auth_keys_to_organization.rb
+++ b/db/migrate/20181120031753_add_full_o_auth_keys_to_organization.rb
@@ -1,0 +1,6 @@
+class AddFullOAuthKeysToOrganization < ActiveRecord::Migration
+  def change
+    add_column :organizations, :encrypted_oauth_keys, :test
+    add_column :organizations, :encrypted_oauth_keys_iv, :string
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -59,6 +59,8 @@ ActiveRecord::Schema.define(version: 20170202033323) do
     t.string   "org_uid"
     t.boolean  "push_disabled"
     t.boolean  "pull_disabled"
+    t.text     "encrypted_oauth_keys"
+    t.string   "encrypted_oauth_keys_iv"
   end
 
   add_index "organizations", ["oauth_uid"], name: "index_organizations_on_oauth_uid", unique: true

--- a/spec/jobs/all_synchronizations_job_spec.rb
+++ b/spec/jobs/all_synchronizations_job_spec.rb
@@ -11,9 +11,9 @@ describe Maestrano::Connector::Rails::AllSynchronizationsJob do
     end
 
     context 'with active organizations' do
-      let!(:organization_not_linked) { create(:organization, oauth_provider: 'salesforce', oauth_token: nil, sync_enabled: true) }
-      let!(:organization_not_active) { create(:organization, oauth_provider: 'salesforce', oauth_token: '123', sync_enabled: 0) }
-      let!(:organization_to_process) { create(:organization, oauth_provider: 'salesforce', oauth_token: '123', sync_enabled: true) }
+      let!(:organization_not_linked) { create(:organization, oauth_provider: 'salesforce', oauth_keys: nil, sync_enabled: true) }
+      let!(:organization_not_active) { create(:organization, oauth_provider: 'salesforce', oauth_keys: '123', sync_enabled: 0) }
+      let!(:organization_to_process) { create(:organization, oauth_provider: 'salesforce', oauth_keys: '123', sync_enabled: true) }
 
       it 'syncs only active organizations' do
         expect { subject }.to enqueue_job(Maestrano::Connector::Rails::SynchronizationJob).with(organization_to_process.id, anything)


### PR DESCRIPTION
The field 'encrypted_oauth_token' will always be `nil` as we now store the full oauth token: https://github.com/maestrano/marlin-banking-adapter/pull/2/commits/08b255b411f8b690b6e288b7b4956fb64478bc0d

- changed the query to use encrypted_oauth_keys, 
- changed the specs 
- added migration, changed schema for specs