### PR TITLE
Lock sqlite3 to 1.3.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gemspec
 # Add dependencies to develop your gem here.
 group :development do
   gem 'activerecord-jdbcsqlite3-adapter', platforms: :jruby
-  gem 'sqlite3', platforms: :ruby
+  gem 'sqlite3', '~> 1.3.13', platforms: :ruby
 end
 
 group :test do


### PR DESCRIPTION
sqlite3 1.4 is conflicting with sqlite3_adapter which requires 1.3.x

See https://github.com/rails/rails/issues/35153